### PR TITLE
Adds theme runtime and component variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Astro build output
 dist/
 .astro/
+.opencode/
 
 test-results/
 playwright-report/

--- a/context/cycles/01-theme-runtime-and-component-variants/aar.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/aar.md
@@ -1,0 +1,25 @@
+1. Did it go as planned? [Yes / No] -- Yes; the cycle shipped the full planned scope (theme runtime deepening plus `IconButton`, `NavTile`, `Cartouche`, and `CTA` primary-path refactors) with all closure checks green.
+2. What changed from the PRD plan:
+   - Added explicit real-browser first-paint coverage (`tests/theme-first-paint.spec.ts`) as a durable verification path for no-**Theme flash** behavior.
+   - Fixed a discovered boot-path gap where light/system-light first paint could keep a dark fallback favicon until hydration; favicon is now set coherently at commit.
+   - Standardized active theme-control semantics on `aria-pressed` while preserving class-based styling hooks for existing UI behavior.
+   - Component deduplication converged on one primary render path per component, but implementation strategy varied by a shared rubric: utility extraction for higher-behavior components and in-component consolidation for lower-complexity presentational components.
+3. ADRs made during this cycle (reference INDEX.md rows):
+   - None. No qualifying hard-to-reverse architectural decision required an ADR in this cycle.
+4. New considerations or constraints surfaced:
+   - Keep Playwright suites that share a managed web server sequential to avoid transient startup collisions.
+   - Keep `@firstpaint` verification as a required closure signal before any future boot-code deletion or consolidation.
+   - Use one explicit leverage/locality/testability decision rubric per component-refactor slice to avoid accidental strategy drift.
+5. Proposed future features or ideas:
+   - Consider a follow-on cycle to activate one **Planned section** only when it has real content and a clear product intent.
+   - Add a small contributor guide describing when to choose helper extraction versus in-component consolidation for Astro component refactors.
+   - Expand route-surface contract tests for other high-importance components where behavior is currently protected only by snapshots.
+6. Patterns across parent issue AARs:
+   - Parent issue #15 closed with complete sub-issue coverage and no unresolved closure flags.
+   - Theme correctness was strongest when contract constants were shared across boot/runtime/tests and verified through both unit and browser paths.
+   - Behavior-preserving UI refactors were most stable when validated through public route surfaces (`/`, `/writing`) rather than template-internal assertions.
+7. Carry-forward to the next cycle:
+   - Preserve the current **Accessibility baseline** and **Visual baseline** expectations as default gates for new work.
+   - Keep performance budgets as descriptive signals unless an explicitly scoped future cycle changes that policy.
+   - Retain no-**Theme flash** as a non-negotiable quality bar for any theme-related changes.
+8. Cycle decision: pivot / new feature / feature complete -- new feature. The product still has intentionally inactive planned sections and clear next-scope opportunities, while this cycle's deepening goals are complete and stable.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/16-canonical-theme-runtime-contract/aar.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/16-canonical-theme-runtime-contract/aar.md
@@ -1,0 +1,8 @@
+1. Did it go as planned? [Yes / No] -- Yes; the canonical theme runtime contract was introduced and adopted by runtime and tests without changing the no-theme-flash protection strategy.
+2. What changed from the sub-issue plan:
+   - Added explicit shared constants/selectors in the contract (`FAVICON_SELECTOR`, `FAVICON_TARGETS`) to remove duplication across boot/runtime/tests.
+   - Updated inline boot script variable injection using Astro `define:vars` after Lighthouse surfaced a syntax regression from non-interpolated inline script tokens.
+3. Carry-forward -- flags to write in the parent, divergence to note for future siblings, notes for the parent issue's AAR:
+   - No sibling-blocking divergence; this slice is stable and mergeable.
+   - Carry forward: preserve real-browser first-paint verification in later theme slices before any boot-path deletion/consolidation.
+   - Carry forward: keep markdown checkbox notation (`[ ]` / `[x]`) for closure tracking artifacts.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/16-canonical-theme-runtime-contract/sub-issue.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/16-canonical-theme-runtime-contract/sub-issue.md
@@ -98,3 +98,26 @@ Design-it-twice:
 - Source PRD: `context/cycles/01-theme-runtime-and-component-variants/prd.md`.
 - Existing no-**Theme flash** behavior must remain protected while this contract
   is introduced.
+
+## Closure
+
+Status: Closed
+
+Acceptance criteria check:
+
+- [x] Valid **Theme preference** values and storage key are centralized in
+  `src/utils/theme-runtime-contract.ts`.
+- [x] Actual theme resolution for light, dark, and system preferences is covered
+  in `src/utils/theme-runtime-contract.test.ts`.
+- [x] Document attribute decisions are covered in
+  `src/utils/theme-runtime-contract.test.ts`.
+- [x] Favicon target selection is covered in
+  `src/utils/theme-runtime-contract.test.ts`.
+- [x] Production code and tests consume the contract (for example
+  `src/utils/theme-manager.ts`, `src/utils/theme-manager.test.ts`,
+  `tests/a11y.spec.ts`, and `tests/visual.spec.ts`).
+- [x] No boot-code deletion is included in this slice.
+
+Verification run:
+
+- [x] `pnpm test:unit` (17 tests passed).

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/16-canonical-theme-runtime-contract/sub-issue.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/16-canonical-theme-runtime-contract/sub-issue.md
@@ -1,0 +1,100 @@
+# Issue #16: Canonical Theme Runtime Contract
+
+## Description
+
+Define the smallest canonical theme runtime contract for valid preferences,
+storage key, actual theme resolution, document attributes, and favicon target
+selection. Use this slice to make theme behavior reviewable through one explicit
+surface before changing boot or interaction adapters.
+
+## Dependency Classification
+
+| Dependency                                          | Category            | Testing strategy                                                                           |
+| --------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------ |
+| Theme preference values and storage key             | In-process          | Test directly through the exported contract.                                               |
+| Actual theme resolution for light, dark, and system | Local-substitutable | Substitute `matchMedia` behavior in unit tests.                                            |
+| Document attribute decisions                        | In-process          | Test generated attribute values without requiring a browser paint.                         |
+| Favicon target selection                            | In-process          | Test selected target values through the contract.                                          |
+| Browser first-paint behavior                        | Irreplaceable       | Preserve for later narrow real-browser verification before boot deletion or consolidation. |
+
+## Interface Design
+
+Entry points:
+
+- Export one contract module consumed by boot, interaction, and tests.
+- Keep valid **Theme preference** values, storage key, actual theme resolution,
+  document attribute decisions, and favicon target selection in that contract.
+
+Inputs:
+
+- Stored preference candidate.
+- System dark-mode match state.
+
+Outputs:
+
+- Normalized **Theme preference**.
+- Actual resolved theme.
+- Document attributes to apply.
+- Favicon target for the resolved theme.
+
+Invariants:
+
+- Invalid stored values fall back to system preference semantics.
+- Light and dark preferences resolve without consulting system state.
+- System preference resolves from the current system match state.
+- Contract exports remain smaller than the current scattered runtime surface.
+
+Error modes:
+
+- Storage may contain an invalid value.
+- System preference may be unavailable in non-browser tests.
+
+Design-it-twice:
+
+- Alternative A: minimal surface with plain functions and constants for
+  preferences, storage, resolution, attributes, and favicon selection.
+- Alternative B: common-caller object that returns all document and favicon
+  decisions in one call for boot and interaction adapters.
+- Chosen design: start with Alternative A because the PRD prioritizes a small
+  explicit runtime contract and reduced export surface.
+- Rejected design: Alternative B may be useful later, but it risks bundling
+  unrelated decisions before the actual callers prove they need a combined
+  shape.
+
+## Acceptance Criteria
+
+- Valid **Theme preference** values and storage key are defined in one contract
+  module.
+- Actual theme resolution for light, dark, and system preferences is covered by
+  unit tests.
+- Document attribute decisions are covered by unit tests.
+- Favicon target selection is covered by unit tests.
+- Production code and tests consume the contract instead of redefining
+  equivalent theme values.
+- No boot-code deletion is performed in this slice unless existing tests and
+  first-paint checks already prove it is safe.
+
+## Proposed Tests
+
+- Unit test valid preference normalization, including invalid stored values.
+- Unit test actual theme resolution for explicit light, explicit dark, system
+  light, and system dark.
+- Unit test document attribute decisions for each resolved theme.
+- Unit test favicon target selection for each resolved theme.
+- Existing `pnpm test:unit` passes.
+
+## Affected Artifacts
+
+- Theme runtime contract module.
+- Theme boot adapter imports, only where needed to consume the contract without
+  changing first-paint behavior.
+- Theme interaction adapter imports, only where needed to consume the contract.
+- Theme unit tests.
+
+## Dependencies
+
+- Parent issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md`.
+- Source PRD: `context/cycles/01-theme-runtime-and-component-variants/prd.md`.
+- Existing no-**Theme flash** behavior must remain protected while this contract
+  is introduced.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/17-theme-boot-first-paint-verification/aar.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/17-theme-boot-first-paint-verification/aar.md
@@ -1,0 +1,9 @@
+1. Did it go as planned? [Yes / No] -- Yes; first-paint coverage was added for `/` and `/writing` across explicit and system preference cases, and the boot path now sets the active favicon at commit time.
+2. What changed from the sub-issue plan:
+   - Added a dedicated Playwright first-paint suite (`tests/theme-first-paint.spec.ts`) with an 8-case route/theme matrix.
+   - The tracer-bullet surfaced a real gap: light/system-light cases kept the dark fallback favicon at commit.
+   - Applied a minimal boot fix by setting favicon immediately in the inline script and injecting `FAVICON_SELECTOR` from the canonical contract.
+3. Carry-forward -- flags to write in the parent, divergence to note for future siblings, notes for the parent issue's AAR:
+   - No sibling-blocking divergence; this slice is stable and mergeable.
+   - Carry forward: keep `@firstpaint` as the real-browser verification path before any future boot deletion/consolidation.
+   - Carry forward: active theme control representation (`aria-pressed`/`data-state`/class naming) remains for the interaction-alignment slice, not this boot verification slice.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/17-theme-boot-first-paint-verification/sub-issue.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/17-theme-boot-first-paint-verification/sub-issue.md
@@ -1,0 +1,149 @@
+# Issue #17: Theme Boot First-Paint Verification
+
+## Description
+
+Protect the pre-paint theme boot path with a narrow real-browser verification
+slice for `/` and `/writing` before any boot-adjacent deletion or consolidation.
+Align the inline boot adapter with the canonical theme runtime contract only
+where that preserves first-paint behavior and makes the no-**Theme flash**
+evidence reviewable.
+
+## Dependency Classification
+
+| Dependency                                        | Category            | Testing strategy                                                                                                         |
+| ------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Canonical theme runtime contract                  | In-process          | Consume existing constants and decisions directly where Astro can safely inject them into the inline boot script.        |
+| Browser first paint on `/` and `/writing`         | Irreplaceable       | Use a narrow Playwright/browser check that observes the initial document theme state before normal post-load assertions. |
+| `localStorage` theme preference before navigation | Local-substitutable | Seed preference with `page.addInitScript` or equivalent browser setup before the page runs app scripts.                  |
+| System color-scheme preference                    | Local-substitutable | Use Playwright color-scheme emulation for dark and light system cases.                                                   |
+| Favicon link target after boot                    | In-process          | Assert the active non-media favicon target follows the resolved theme after the boot script runs.                        |
+| Inline Astro boot script execution order          | Irreplaceable       | Keep verification in a real Astro-built or served page rather than jsdom-only tests.                                     |
+
+## Interface Design
+
+Entry points:
+
+- Existing inline boot script in `src/layouts/base-layout.astro`.
+- Existing canonical contract exports from
+  `src/utils/theme-runtime-contract.ts`.
+- A narrow first-paint verification path under the Playwright test suite.
+
+Inputs:
+
+- Page path: `/` or `/writing`.
+- Stored **Theme preference**: `light`, `dark`, or `system`.
+- Emulated system color-scheme for system preference checks.
+
+Outputs:
+
+- Initial `html.dark` class state.
+- Initial `data-theme` and `data-theme-preference` attributes.
+- Active non-media favicon `href` target.
+- A documented verification result showing no visible **Theme flash** for the
+  covered paths and preferences.
+
+Invariants:
+
+- The boot script applies `data-theme`, `data-theme-preference`, and `.dark`
+  before the first visible frame.
+- Invalid or missing stored preferences retain system preference semantics.
+- Favicon target selection remains consistent with the resolved actual theme.
+- No boot code is deleted or consolidated in this slice unless the same
+  first-paint verification proves behavior is unchanged.
+
+Error modes:
+
+- Browser storage access may throw or be unavailable.
+- `matchMedia` may be unavailable only outside the real-browser verification
+  path.
+- Inline script token injection can regress if contract values are not injected
+  as serializable Astro variables.
+- A verification that waits for network idle or DOMContentLoaded may miss a
+  first-paint regression.
+
+Design-it-twice:
+
+- Alternative A: add a dedicated Playwright first-paint spec that seeds storage
+  and color-scheme before navigation, then checks the earliest observable theme
+  state and favicon target without changing the runtime surface.
+- Alternative B: extract the inline boot logic into a generated shared helper so
+  unit tests and boot code execute the same source.
+- Chosen design: Alternative A because the primary risk is real-browser paint
+  ordering, and the current contract already gives the boot script the small
+  values it needs.
+- Rejected design: Alternative B increases bundling and script-order risk before
+  deletion/consolidation has evidence to justify the extra seam.
+
+## Acceptance Criteria
+
+- Real-browser verification covers `/` and `/writing` for explicit light,
+  explicit dark, system-light, and system-dark first-paint cases.
+- Verification checks the initial `data-theme`, `data-theme-preference`, and
+  `.dark` class state before relying on client-side theme manager hydration.
+- Verification checks the active non-media favicon target follows the resolved
+  actual theme.
+- The inline boot path consumes the canonical contract values that are safe to
+  inject without changing first-paint behavior.
+- No visible **Theme flash** is observed during the verification run.
+- No boot-code deletion or consolidation is included unless deletion-test
+  evidence is recorded in this sub-issue.
+- `pnpm test:unit` and the first-paint browser verification pass.
+
+## Proposed Tests
+
+- Add or update a Playwright spec that seeds `localStorage` before page scripts
+  run and visits `/` and `/writing` for `light`, `dark`, and `system`.
+- For system preference, run separate browser contexts or test cases with light
+  and dark color-scheme emulation.
+- Assert `document.documentElement` theme attributes and `.dark` class as early
+  as the verification method allows.
+- Assert `link[rel="icon"]:not([media])` resolves to the expected favicon target
+  for the actual theme.
+- Run `pnpm test:unit`.
+- Run the targeted first-paint browser verification command, or document why the
+  existing `pnpm test:visual` command is the executed real-browser path.
+
+## Affected Artifacts
+
+- `src/layouts/base-layout.astro`
+- `src/utils/theme-runtime-contract.ts`, only if an already-planned boot-safe
+  export is missing.
+- Playwright theme first-paint verification under `tests/`.
+- Existing visual or accessibility tests only if they need shared setup cleanup
+  after the first-paint path is introduced.
+
+## Dependencies
+
+- Parent issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md`.
+- Previous sub-issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/16-canonical-theme-runtime-contract/sub-issue.md`.
+- Source PRD: `context/cycles/01-theme-runtime-and-component-variants/prd.md`.
+- Current boot script in `src/layouts/base-layout.astro`.
+- Current contract in `src/utils/theme-runtime-contract.ts`.
+- Current Playwright configuration and `/`, `/writing` route coverage.
+
+## Closure
+
+Status: Closed
+
+Acceptance criteria check:
+
+- [x] Real-browser verification covers `/` and `/writing` for explicit light,
+  explicit dark, system-light, and system-dark first-paint cases in
+  `tests/theme-first-paint.spec.ts`.
+- [x] Verification checks initial `data-theme`, `data-theme-preference`, and
+  `.dark` class state before hydration.
+- [x] Verification checks active non-media favicon target with
+  `FAVICON_SELECTOR` and `FAVICON_TARGETS`.
+- [x] Inline boot path consumes canonical contract values via
+  `define:vars` (`THEME_STORAGE_KEY`, `THEME_PREFERENCES`, `FAVICON_SELECTOR`,
+  `FAVICON_TARGETS`) in `src/layouts/base-layout.astro`.
+- [x] No visible **Theme flash** observed in first-paint verification runs.
+- [x] No boot deletion or consolidation is included in this slice.
+- [x] `pnpm test:unit` and targeted first-paint browser verification pass.
+
+Verification run:
+
+- [x] `pnpm test --grep @firstpaint` (8 tests passed).
+- [x] `pnpm test:unit` (17 tests passed).

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/18-theme-interaction-state-alignment/aar.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/18-theme-interaction-state-alignment/aar.md
@@ -1,0 +1,8 @@
+1. Did it go as planned? [Yes / No] -- Yes; interaction state now uses explicit `aria-pressed` semantics alongside class styling, with tests proving single-active coherence, attribute updates, favicon alignment, and guarded system-change behavior.
+2. What changed from the sub-issue plan:
+   - Added a small compatibility hardening in `theme-manager` by supporting legacy `matchMedia.addListener` paths in addition to modern `addEventListener`.
+   - Deepened unit coverage beyond control-state assertions to include document attribute coherence and favicon updates across explicit and system transitions.
+3. Carry-forward -- flags to write in the parent, divergence to note for future siblings, notes for the parent issue's AAR:
+   - No sibling-blocking divergence; this slice is stable and mergeable.
+   - Carry forward: keep `aria-pressed` as the semantic source of truth for active theme control state, with `icon-button--active` retained as presentation.
+   - Carry forward: retain legacy `matchMedia` listener coverage to prevent environment-specific regressions.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/18-theme-interaction-state-alignment/sub-issue.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/18-theme-interaction-state-alignment/sub-issue.md
@@ -10,13 +10,13 @@ and enforcing it through tests.
 
 ## Dependency Classification
 
-| Dependency | Category | Testing strategy |
-| --- | --- | --- |
-| Canonical theme runtime contract (`theme-runtime-contract`) | In-process | Consume exported preference/theme/attribute/favicon decisions directly through the interaction adapter surface. |
-| Theme interaction adapter (`theme-manager`) | In-process | Test behavior through exported manager functions and initialization path. |
-| Theme controls DOM (`#light-theme-button`, `#system-theme-button`, `#dark-theme-button`) | Local-substitutable | Use jsdom/happy-dom unit tests with real DOM nodes and events. |
-| System color-scheme change events (`matchMedia`) | Local-substitutable | Stub `matchMedia` and change listeners to simulate system dark/light changes. |
-| Browser runtime behavior after hydration | Irreplaceable | Confirm with existing Playwright route coverage after unit behavior is aligned. |
+| Dependency                                                                               | Category            | Testing strategy                                                                                                |
+| ---------------------------------------------------------------------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Canonical theme runtime contract (`theme-runtime-contract`)                              | In-process          | Consume exported preference/theme/attribute/favicon decisions directly through the interaction adapter surface. |
+| Theme interaction adapter (`theme-manager`)                                              | In-process          | Test behavior through exported manager functions and initialization path.                                       |
+| Theme controls DOM (`#light-theme-button`, `#system-theme-button`, `#dark-theme-button`) | Local-substitutable | Use jsdom/happy-dom unit tests with real DOM nodes and events.                                                  |
+| System color-scheme change events (`matchMedia`)                                         | Local-substitutable | Stub `matchMedia` and change listeners to simulate system dark/light changes.                                   |
+| Browser runtime behavior after hydration                                                 | Irreplaceable       | Confirm with existing Playwright route coverage after unit behavior is aligned.                                 |
 
 ## Interface Design
 
@@ -87,8 +87,8 @@ Design-it-twice:
 - Extend `src/utils/theme-manager.test.ts` to assert the chosen active control
   representation for each preference transition.
 - Add/adjust tests for single-active invariant across all three controls.
-- Verify system change event behavior when preference is `system` versus explicit
-  `light`/`dark`.
+- Verify system change event behavior when preference is `system` versus
+  explicit `light`/`dark`.
 - Verify favicon target and document attributes after interaction updates.
 - Run `pnpm test:unit`.
 - Run targeted browser checks (`pnpm test --grep @firstpaint` and/or
@@ -101,8 +101,8 @@ Design-it-twice:
 - `src/utils/theme-manager.test.ts`
 - `src/components/theme-controls.astro`, only if chosen semantics require
   explicit initial attributes.
-- `tests/visual.spec.ts` or related browser tests only if expectation updates are
-  needed for intentional interaction-state rendering changes.
+- `tests/visual.spec.ts` or related browser tests only if expectation updates
+  are needed for intentional interaction-state rendering changes.
 
 ## Dependencies
 
@@ -110,9 +110,6 @@ Design-it-twice:
   `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md`.
 - Previous sub-issue:
   `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/17-theme-boot-first-paint-verification/sub-issue.md`.
-- Canonical contract:
-  `src/utils/theme-runtime-contract.ts`.
-- Interaction adapter:
-  `src/utils/theme-manager.ts`.
-- Theme control surface:
-  `src/components/theme-controls.astro`.
+- Canonical contract: `src/utils/theme-runtime-contract.ts`.
+- Interaction adapter: `src/utils/theme-manager.ts`.
+- Theme control surface: `src/components/theme-controls.astro`.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/18-theme-interaction-state-alignment/sub-issue.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/18-theme-interaction-state-alignment/sub-issue.md
@@ -1,0 +1,118 @@
+# Issue #18: Theme Interaction State Alignment
+
+## Description
+
+Align theme interaction behavior with the canonical runtime contract so control
+state, document attributes, and favicon updates remain coherent after user
+actions and system theme changes. Resolve the parent flag for active theme
+control representation by choosing one explicit accessibility-and-styling shape
+and enforcing it through tests.
+
+## Dependency Classification
+
+| Dependency | Category | Testing strategy |
+| --- | --- | --- |
+| Canonical theme runtime contract (`theme-runtime-contract`) | In-process | Consume exported preference/theme/attribute/favicon decisions directly through the interaction adapter surface. |
+| Theme interaction adapter (`theme-manager`) | In-process | Test behavior through exported manager functions and initialization path. |
+| Theme controls DOM (`#light-theme-button`, `#system-theme-button`, `#dark-theme-button`) | Local-substitutable | Use jsdom/happy-dom unit tests with real DOM nodes and events. |
+| System color-scheme change events (`matchMedia`) | Local-substitutable | Stub `matchMedia` and change listeners to simulate system dark/light changes. |
+| Browser runtime behavior after hydration | Irreplaceable | Confirm with existing Playwright route coverage after unit behavior is aligned. |
+
+## Interface Design
+
+Entry points:
+
+- `initializeThemeManager()` for interactive setup.
+- `setLightTheme()`, `setDarkTheme()`, and `setSystemTheme()` for explicit
+  preference transitions.
+- Theme controls rendered by `src/components/theme-controls.astro`.
+
+Inputs:
+
+- User click/keyboard activation on the three theme controls.
+- Current stored preference and document attributes.
+- System dark-mode change events while preference is `system`.
+
+Outputs:
+
+- Updated `data-theme` and `data-theme-preference` on `<html>`.
+- Updated active control representation for exactly one selected preference.
+- Updated active favicon target for the resolved actual theme.
+
+Invariants:
+
+- Theme interaction uses contract decisions for resolved actual theme and
+  document attributes.
+- Exactly one theme control is represented as active at any time.
+- Active control representation remains accessible and styleable.
+- Favicon target stays coherent with the resolved actual theme after any
+  preference change.
+
+Error modes:
+
+- Missing controls on a page should fail safely without breaking unrelated page
+  behavior.
+- Storage operations may fail; interaction still updates in-memory DOM state.
+- `matchMedia` event APIs may differ across environments and must be guarded in
+  tests and runtime.
+
+Design-it-twice:
+
+- Alternative A: keep class-only active state (`icon-button--active`) and add
+  test coverage for uniqueness and coherence.
+- Alternative B: add semantic state (`aria-pressed` or `data-state`) as the
+  canonical active indicator and keep class names as presentational affordance.
+- Chosen design: Alternative B for stronger accessibility semantics and clearer
+  styling intent while preserving existing class-based visual hooks.
+- Rejected design: Alternative A is simpler, but it leaves active-state meaning
+  implicit and less explicit for assistive tooling and future maintainers.
+
+## Acceptance Criteria
+
+- Active theme control representation is explicitly defined and implemented in
+  the interaction path (`aria-pressed`, `data-state`, class names, or justified
+  combination).
+- Unit tests verify that exactly one control is active for light, dark, and
+  system preferences.
+- Unit tests verify document attribute coherence (`data-theme`,
+  `data-theme-preference`, and `.dark`) for explicit and system transitions.
+- Unit tests verify favicon updates remain coherent with resolved actual theme.
+- System theme change handling updates theme only when preference is `system`.
+- `pnpm test:unit` passes with the deepened interaction coverage.
+- Existing Playwright checks relevant to theme behavior remain green or show
+  only intentional updates.
+
+## Proposed Tests
+
+- Extend `src/utils/theme-manager.test.ts` to assert the chosen active control
+  representation for each preference transition.
+- Add/adjust tests for single-active invariant across all three controls.
+- Verify system change event behavior when preference is `system` versus explicit
+  `light`/`dark`.
+- Verify favicon target and document attributes after interaction updates.
+- Run `pnpm test:unit`.
+- Run targeted browser checks (`pnpm test --grep @firstpaint` and/or
+  `pnpm test:visual`) to ensure no interaction regressions leak into route
+  behavior.
+
+## Affected Artifacts
+
+- `src/utils/theme-manager.ts`
+- `src/utils/theme-manager.test.ts`
+- `src/components/theme-controls.astro`, only if chosen semantics require
+  explicit initial attributes.
+- `tests/visual.spec.ts` or related browser tests only if expectation updates are
+  needed for intentional interaction-state rendering changes.
+
+## Dependencies
+
+- Parent issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md`.
+- Previous sub-issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/17-theme-boot-first-paint-verification/sub-issue.md`.
+- Canonical contract:
+  `src/utils/theme-runtime-contract.ts`.
+- Interaction adapter:
+  `src/utils/theme-manager.ts`.
+- Theme control surface:
+  `src/components/theme-controls.astro`.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/27-icon-button-primary-render-path/aar.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/27-icon-button-primary-render-path/aar.md
@@ -1,0 +1,9 @@
+1. Did it go as planned? [Yes / No] -- Yes; `IconButton` now renders through one primary path with tag-specific semantics only, and variant class decisions are centralized in a test-covered utility contract.
+2. What changed from the sub-issue plan:
+   - Introduced `src/utils/icon-button-contract.ts` to own variant class selection and class composition, then updated `src/components/icon-button.astro` to consume that contract.
+   - Reduced duplicate attribute wiring by creating shared accessibility/styling attributes once, while preserving `<a>` `href` and `<button>` `type` semantics.
+   - Kept the existing caller surface intact (`as`, `variant`, `ariaLabel`, `title`, pass-through attrs), including compatibility with theme active-state class usage.
+3. Carry-forward -- flags to write in the parent, divergence to note for future siblings, notes for the parent issue's AAR:
+   - No divergence requiring parent flags; this slice stayed within the planned boundaries.
+   - Carry forward: for upcoming variant-path refactors (`NavTile`, `Cartouche`, `CTA`), prefer utility-level class contracts plus minimal semantic branching in Astro templates.
+   - Carry forward: avoid running Playwright suites that rely on the same web server in parallel; run sequentially to prevent transient startup conflicts.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/27-icon-button-primary-render-path/sub-issue.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/27-icon-button-primary-render-path/sub-issue.md
@@ -1,0 +1,99 @@
+# Issue #27: IconButton Primary Render Path
+
+## Description
+
+Refactor `IconButton` so it has one primary render path with explicit semantic
+differences only where HTML responsibility differs (`<a>` vs `<button>`). Keep
+variant behavior (`default`, `inherit`, `borderless`) and existing call sites
+intact while reducing duplicated class and attribute logic.
+
+## Dependency Classification
+
+| Dependency                                              | Category            | Testing strategy                                                                                  |
+| ------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------- |
+| `IconButton` public props surface (`as`, `variant`, etc.) | In-process          | Verify behavior through rendered output and existing call sites, not internal helper sequencing. |
+| Theme controls and social links using `IconButton`      | Local-substitutable | Validate in local page routes and Playwright checks where those surfaces already render.         |
+| Tailwind utility class behavior                          | Irreplaceable       | Confirm no unintended visual drift in real-browser visual snapshots.                             |
+| Accessibility behavior for focus/label semantics         | Irreplaceable       | Re-run existing route-level axe checks and ensure zero violations.                               |
+
+## Interface Design
+
+Entry points:
+
+- `src/components/icon-button.astro` as the only public component surface.
+- Existing call sites in `src/components/theme-controls.astro`,
+  `src/components/social-links.astro`, and `src/components/Navigation.astro`.
+
+Inputs:
+
+- `as` (`"button" | "a"`), `href`, `ariaLabel`, `title`, `type`, `variant`,
+  and pass-through attributes.
+
+Outputs:
+
+- Rendered interactive element with consistent base classes, variant classes,
+  and caller-provided attributes.
+- Preserved focus-visible, hover, and active-state styling hooks.
+
+Invariants:
+
+- `aria-label` is always present from `ariaLabel`.
+- `title` defaults to `ariaLabel` when not explicitly provided.
+- Exactly one variant class recipe is applied per render.
+- `<button>` keeps explicit `type`; `<a>` keeps `href` and link-only attrs.
+
+Error modes:
+
+- Invalid or missing `href` while `as="a"` can produce a non-functional link.
+- Caller-provided `class` or spread attrs may override expected styling.
+
+Design-it-twice:
+
+- Alternative A: keep inline branching in Astro template but reduce duplication
+  by centralizing class map and shared attributes.
+- Alternative B: extract a tiny class/attribute decision helper in `src/utils`
+  with unit tests, then use one Astro render scaffold with minimal tag branch.
+- Chosen design: Alternative B for better testability and clearer contract of
+  variant decisions without coupling tests to Astro template internals.
+- Rejected design: Alternative A is lower churn, but it keeps behavior decisions
+  embedded in template structure and harder to test in isolation.
+
+## Acceptance Criteria
+
+- `IconButton` renders through one primary component path with only semantic
+  tag-specific branching (`<a>` vs `<button>`).
+- Variant class decisions are centralized and no longer duplicated across
+  multiple unrelated conditional blocks.
+- Existing call sites render without API changes.
+- Theme control active-state class (`icon-button--active`) remains available and
+  unaffected.
+- `pnpm test:unit` passes with any added helper tests.
+- `pnpm test:a11y` remains green for covered routes.
+- `pnpm test:visual` remains green or records only intentional diffs.
+
+## Proposed Tests
+
+- Add unit tests for extracted variant/class decision helper (if introduced).
+- Confirm `IconButton` still supports `default`, `inherit`, and `borderless`
+  variants through route-level rendering.
+- Run `pnpm test:unit`.
+- Run `pnpm test:a11y`.
+- Run `pnpm test:visual` and review any intentional snapshot updates.
+
+## Affected Artifacts
+
+- `src/components/icon-button.astro`
+- `src/utils/*` helper module for class/attribute decisions, only if introduced.
+- Unit tests for helper logic under `src/utils/*.test.ts`, only if introduced.
+- `tests/visual.spec.ts` and/or snapshots only if intentional rendering changes
+  occur.
+
+## Dependencies
+
+- Parent issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md`.
+- Previous sub-issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/18-theme-interaction-state-alignment/sub-issue.md`.
+- Current component surface: `src/components/icon-button.astro`.
+- Current route-level regression suite: `tests/visual.spec.ts` and
+  `tests/a11y.spec.ts`.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/28-nav-tile-primary-render-path/aar.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/28-nav-tile-primary-render-path/aar.md
@@ -1,0 +1,8 @@
+1. Did it go as planned? [Yes / No] -- Yes; `NavTile` now renders through one shared scaffold, with state-specific behavior centralized in a small utility contract and covered by unit tests.
+2. What changed from the sub-issue plan:
+   - Introduced `src/utils/nav-tile-contract.ts` to centralize enabled/disabled class and semantic decisions.
+   - Updated `src/components/nav-tile.astro` to a single render path with a narrow state branch for trailing content (`disabledLabel` vs arrow icon).
+   - Added helper tests in `src/utils/nav-tile-contract.test.ts` for disabled semantics, enabled semantics, and state-specific class switching.
+3. Carry-forward -- flags to write in the parent, divergence to note for future siblings, notes for the parent issue's AAR:
+   - No sibling-blocking divergence; this slice remains within planned scope and is mergeable.
+   - Carry forward: continue the same pattern for upcoming component slices (`Cartouche`, `CTA`): extract state/variant decisions into a testable utility and keep Astro templates on one primary render scaffold.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/28-nav-tile-primary-render-path/sub-issue.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/28-nav-tile-primary-render-path/sub-issue.md
@@ -1,0 +1,98 @@
+# Issue #28: NavTile Primary Render Path
+
+## Description
+
+Refactor `NavTile` so it has one primary render path that preserves current
+enabled and disabled behavior without duplicating markup. Keep existing call
+sites and visual tone intact while centralizing class and state decisions.
+
+## Dependency Classification
+
+| Dependency                                                     | Category            | Testing strategy                                                                                  |
+| -------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------- |
+| `NavTile` public props surface (`href`, `title`, `disabled`)  | In-process          | Verify behavior through rendered output and caller-facing props, not internal helper sequencing. |
+| Home surface nav usage in `src/pages/index.astro`             | Local-substitutable | Validate through route rendering and existing Playwright route coverage for `/`.                 |
+| Tailwind utility class behavior for tile states               | Irreplaceable       | Confirm no unintended visual drift via real-browser visual snapshots.                            |
+| Accessibility semantics for disabled and enabled interactions  | Irreplaceable       | Re-run route-level axe checks and verify zero violations.                                        |
+
+## Interface Design
+
+Entry points:
+
+- `src/components/nav-tile.astro` as the only public component surface.
+- Existing call sites in `src/pages/index.astro`.
+
+Inputs:
+
+- `href`, `title`, `description`, `disabled`, and `disabledLabel`.
+
+Outputs:
+
+- A rendered anchor tile with consistent shared structure.
+- State-specific styling and affordances for enabled versus disabled behavior.
+
+Invariants:
+
+- `NavTile` keeps one shared structural scaffold for both states.
+- Enabled tiles preserve hover/focus/active affordances and arrow icon.
+- Disabled tiles preserve `aria-disabled="true"`, non-interactive behavior, and
+  `disabledLabel` rendering.
+- Existing visual hierarchy for `title` and `description` remains intact.
+
+Error modes:
+
+- Missing or invalid `href` can produce non-functional navigation.
+- Caller-provided `disabledLabel` may overflow or create layout pressure.
+
+Design-it-twice:
+
+- Alternative A (minimal surface): keep all decisions inside
+  `nav-tile.astro` and only centralize shared class fragments/constants.
+- Alternative B (common-caller optimized): extract a small contract helper in
+  `src/utils` that returns state-specific class and attribute decisions, then
+  keep Astro template focused on one markup path.
+- Chosen design: Alternative B for higher testability and cleaner separation of
+  state decision logic from template structure.
+- Rejected design: Alternative A is lower churn but keeps behavior decisions
+  tightly coupled to template branching and harder to verify in isolation.
+
+## Acceptance Criteria
+
+- `NavTile` renders through one primary component path with shared structure.
+- Enabled and disabled state decisions are centralized instead of duplicated
+  across two full markup branches.
+- Existing call sites render without API changes.
+- Disabled affordance (`aria-disabled`, non-interactive behavior, label) remains
+  intact.
+- `pnpm test:unit` passes with any added helper tests.
+- `pnpm test:a11y` remains green for covered routes.
+- `pnpm test:visual` remains green or records only intentional diffs.
+
+## Proposed Tests
+
+- Add unit tests for extracted NavTile state/class decision helper (if
+  introduced).
+- Confirm home route NavTile variants still render as intended via route-level
+  checks.
+- Run `pnpm test:unit`.
+- Run `pnpm test:a11y`.
+- Run `pnpm test:visual` and review any intentional snapshot updates.
+
+## Affected Artifacts
+
+- `src/components/nav-tile.astro`
+- `src/utils/*` helper module for NavTile state/class decisions, only if
+  introduced.
+- Unit tests for helper logic under `src/utils/*.test.ts`, only if introduced.
+- `tests/visual.spec.ts` and/or snapshots only if intentional rendering changes
+  occur.
+
+## Dependencies
+
+- Parent issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md`.
+- Previous sub-issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/27-icon-button-primary-render-path/sub-issue.md`.
+- Current component surface: `src/components/nav-tile.astro`.
+- Current route-level regression suite: `tests/visual.spec.ts` and
+  `tests/a11y.spec.ts`.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/29-cartouche-primary-render-path/aar.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/29-cartouche-primary-render-path/aar.md
@@ -1,0 +1,10 @@
+1. Did it go as planned? [Yes / No] -- Yes; `Cartouche` now renders through one shared scaffold with focused variant decisions, and regression checks stayed green.
+2. What changed from the sub-issue plan:
+   - Added one route-surface contract test in `tests/cartouche.spec.ts` as tracer-bullet first contact, using stable `data-cartouche` markers.
+   - Refactored `src/components/cartouche.astro` from duplicated branch markup to one primary render path with computed `containerClass`, `subtitleClass`, and variant-gated monogram fill pass-through.
+   - Introduced `data-cartouche="true"` and `data-cartouche-variant` markers to keep behavior verification on the public surface without asserting internal template structure.
+   - Verified closure checks with `pnpm test:unit`, `pnpm test:a11y`, and `pnpm test:visual` all passing.
+3. Carry-forward -- flags to write in the parent, divergence to note for future siblings, notes for the parent issue's AAR:
+   - Divergence noted from closed sibling AAR guidance (`27`, `28`): this slice intentionally did not extract a new utility helper because leverage was low under the stated rubric (leverage/locality/testability).
+   - Parent flag added for the future `CTA` sibling to apply the same rubric explicitly instead of assuming extraction-by-default.
+   - No ADR required; no hard-to-reverse architectural decision was introduced in this slice.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/29-cartouche-primary-render-path/sub-issue.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/29-cartouche-primary-render-path/sub-issue.md
@@ -1,0 +1,116 @@
+# Issue #29: Cartouche Primary Render Path
+
+## Description
+
+Refactor `Cartouche` to one primary render path while preserving the distinct
+semantic responsibilities of `hero` and `section` variants. Keep existing
+call sites, visual language, and monogram behavior intact while reducing
+duplicated structure and class branching.
+
+## Dependency Classification
+
+| Dependency                                                              | Category            | Testing strategy                                                                                     |
+| ----------------------------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------- |
+| `Cartouche` public props (`subtitle`, `variant`, `monogramFill`)       | In-process          | Verify rendered output through component contract and existing callers, not internal helper order. |
+| Route usage in `src/pages/index.astro` and `src/pages/writing/index.astro` | Local-substitutable | Validate behavior through local route rendering and existing browser route checks.                  |
+| `MonogramDisplay` integration (`inline`, `forceDark`, optional `fill`) | In-process          | Assert prop mapping and rendering behavior through component-level and route-level checks.          |
+| Tailwind utility class behavior for hero/section styling               | Irreplaceable       | Confirm no unintended visual drift with real-browser visual snapshots.                              |
+| Accessibility and heading/text structure                               | Irreplaceable       | Re-run route-level axe checks and verify zero violations.                                           |
+
+## Interface Design
+
+Entry points:
+
+- `src/components/cartouche.astro` as the only public component surface.
+- Existing call sites in `src/pages/index.astro` and
+  `src/pages/writing/index.astro`.
+
+Inputs:
+
+- `subtitle`, `variant` (`"hero" | "section"`), and optional `monogramFill`.
+
+Outputs:
+
+- A shared rendered Cartouche scaffold with variant-specific style decisions.
+- Correct `MonogramDisplay` usage for both variants.
+
+Invariants:
+
+- One shared structural scaffold renders for both variants.
+- Hero variant preserves accent-as-surface background and foreground pairing.
+- Section variant preserves accent-forward text treatment and optional monogram
+  fill override.
+- Title and subtitle hierarchy remains unchanged.
+- `MonogramDisplay` remains `inline` and `forceDark` in both variants.
+
+Error modes:
+
+- Missing `subtitle` can degrade content clarity.
+- Unexpected `monogramFill` values can reduce visual contrast.
+- Caller-provided surrounding layout classes may alter spacing expectations.
+
+Design-it-twice:
+
+- Alternative A (minimal surface): keep decisions inside `cartouche.astro` and
+  centralize only shared classes and child structure.
+- Alternative B (common-caller optimized): extract variant class/prop decision
+  helper to `src/utils`, then keep `cartouche.astro` as one template scaffold.
+- Decision rubric used (same rubric as sibling component sub-issues):
+  leverage (reusability across callers/components), locality (keep behavior near
+  markup when cognitive load is low), and testability (can key behavior be
+  asserted without introducing a new seam).
+- Chosen design: Alternative A. For `Cartouche`, variant behavior is primarily
+  presentational (class selection + monogram fill pass-through) with a single
+  component seam and two stable callers. Under the rubric, extraction scores low
+  on leverage, neutral-to-negative on locality, and only modestly positive on
+  testability, so the helper boundary is not justified at this stage.
+- Rejected design: Alternative B. It would align mechanically with extracted
+  helper patterns in `IconButton`/`NavTile`, but those components carry higher
+  interaction-state complexity. Applying extraction here only for stylistic
+  consistency risks indirection without enough behavioral payoff.
+- Revisit trigger: if `Cartouche` gains additional stateful variants, shared
+  cross-component style policies, or repeated decision logic in new callers,
+  re-open Alternative B and extract with focused unit tests.
+
+## Acceptance Criteria
+
+- `Cartouche` renders through one primary component path.
+- Variant differences are represented as focused, explicit style/prop decisions
+  instead of duplicated full markup branches.
+- Existing call sites render without API changes.
+- Hero and section visual intent remains intact.
+- `pnpm test:unit` passes (including any component-level updates required by the
+  refactor).
+- `pnpm test:a11y` remains green for covered routes.
+- `pnpm test:visual` remains green or records only intentional diffs.
+
+## Proposed Tests
+
+- Add or adjust tests to verify variant-specific class/prop decisions while
+  asserting one shared structural scaffold.
+- Verify `MonogramDisplay` prop coherence for hero vs section variants,
+  including optional `monogramFill` behavior.
+- Run `pnpm test:unit`.
+- Run `pnpm test:a11y`.
+- Run `pnpm test:visual` and review any intentional snapshot updates.
+
+## Affected Artifacts
+
+- `src/components/cartouche.astro`
+- `src/components/monogram-display.astro`, only if contract adjustments are
+  necessary to preserve behavior.
+- Optional helper/tests under `src/utils/*` only if implementation chooses
+  extraction despite the default design.
+- `tests/visual.spec.ts` and/or snapshots only if intentional rendering changes
+  occur.
+
+## Dependencies
+
+- Parent issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md`.
+- Previous sub-issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/28-nav-tile-primary-render-path/sub-issue.md`.
+- Current component surface: `src/components/cartouche.astro`.
+- Monogram dependency: `src/components/monogram-display.astro`.
+- Current route-level regression suite: `tests/visual.spec.ts` and
+  `tests/a11y.spec.ts`.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/30-cta-primary-render-path/aar.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/30-cta-primary-render-path/aar.md
@@ -1,0 +1,12 @@
+1. Did it go as planned? [Yes / No] -- Yes; `CTA` now renders through one shared scaffold with semantic tag-specific behavior preserved, and all required regression checks passed.
+2. What changed from the sub-issue plan:
+   - Added tracer-bullet first-contact coverage in `tests/cta.spec.ts` through the public `/writing` surface to verify CTA semantic marker and external-link behavior.
+   - Refactored `src/components/cta.astro` to one primary render path using a dynamic element and centralized shared class composition.
+   - Kept tag-specific responsibilities explicit through `tagSpecificAttrs` (`href`/`target`/`rel` for links, `type="button"` for buttons).
+   - Added stable route-surface contract markers (`data-cta`, `data-cta-as`) to verify behavior without coupling tests to template internals.
+   - Resolved the parent targeting flag during pre-activation in `issue.md` and documented rubric-driven in-component consolidation.
+   - Verified closure checks with `pnpm test:unit`, `pnpm test:a11y`, and `pnpm test:visual` all passing.
+3. Carry-forward -- flags to write in the parent, divergence to note for future siblings, notes for the parent issue's AAR:
+   - No new future-sibling flags; this was the final planned component-variant slice under parent issue #15.
+   - No ADR required; no hard-to-reverse architecture decision was introduced in this slice.
+   - Parent issue AAR should record the cross-slice pattern: extraction was used for higher-behavior components (`IconButton`, `NavTile`) while lower-complexity presentational components (`Cartouche`, `CTA`) stayed in-component under the same leverage/locality/testability rubric.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/30-cta-primary-render-path/sub-issue.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/30-cta-primary-render-path/sub-issue.md
@@ -1,0 +1,113 @@
+# Issue #30: CTA Primary Render Path
+
+## Description
+
+Refactor `CTA` to one primary render path while preserving the distinct semantic
+responsibilities of `<a>` and `<button>`. Keep current writing-page call sites,
+visual tone, and external-link affordance intact while reducing duplicated
+branch markup and keeping class/state decisions explicit.
+
+## Dependency Classification
+
+| Dependency | Category | Testing strategy |
+| --- | --- | --- |
+| `CTA` public props surface (`as`, `href`, `external`, `label`, `class`) | In-process | Verify rendered output through the component contract and caller-facing behavior, not internal expression ordering. |
+| Writing route usage in `src/pages/writing/index.astro` | Local-substitutable | Validate behavior through local route rendering and existing route/browser checks for `/writing`. |
+| Tailwind utility class behavior for CTA states | Irreplaceable | Confirm no unintended visual drift via real-browser visual snapshots. |
+| Accessibility semantics for link/button usage and focus behavior | Irreplaceable | Re-run route-level axe checks and verify zero violations. |
+
+## Interface Design
+
+Entry points:
+
+- `src/components/cta.astro` as the only public component surface.
+- Existing call sites in `src/pages/writing/index.astro`.
+
+Inputs:
+
+- `as` (`"a" | "button"`), optional `href`, `external`, `label`, `class`, and
+  pass-through attributes.
+
+Outputs:
+
+- A shared CTA scaffold with consistent class composition and text treatment.
+- Semantic element output (`<a>` or `<button>`) with tag-specific attributes.
+- External-link indicator glyph when `external` is true for anchors.
+
+Invariants:
+
+- One shared CTA structural scaffold renders for both semantic tags.
+- Base CTA class recipe remains unchanged unless intentionally updated.
+- `<a>` keeps `href`, optional `target`, and optional `rel` behavior.
+- `<button>` keeps explicit `type="button"` unless caller overrides with a
+  deliberate attribute.
+- External indicator remains present only for external anchors.
+
+Error modes:
+
+- Missing or invalid `href` while `as="a"` can produce non-functional
+  navigation.
+- Caller-provided classes or spread attrs can override expected styling.
+- Misuse of `external` with non-anchor rendering can create confusing intent.
+
+Design-it-twice:
+
+- Alternative A (minimal surface): keep decisions inside `cta.astro` and
+  consolidate shared scaffold/class composition, with a small semantic tag
+  branch only where responsibilities differ.
+- Alternative B (common-caller optimized): extract a helper in `src/utils` for
+  tag-specific attribute and external-indicator decisions, then keep Astro
+  template as a thin renderer.
+- Decision rubric used: leverage (cross-component/caller reuse), locality (keep
+  behavior near markup when complexity is low), and testability (ability to
+  verify behavior without unnecessary seams).
+- Chosen design: Alternative A. For `CTA`, decision complexity is low and mostly
+  local to one component and one stable caller. Under the rubric, extraction is
+  low leverage, weakly positive at best for testability, and negative for
+  locality due to extra indirection.
+- Rejected design: Alternative B. It would create a helper seam before there is
+  sufficient repeated decision logic or multi-caller pressure to justify it.
+- Revisit trigger: if additional CTA variants/callers introduce repeated
+  attribute/state policies, revisit helper extraction with focused unit tests.
+
+## Acceptance Criteria
+
+- `CTA` renders through one primary component path with only semantic tag
+  branching where HTML responsibility differs.
+- Class composition and shared scaffold are centralized instead of duplicated
+  across full markup branches.
+- Existing call sites render without API changes.
+- External-anchor behavior (`target`, `rel`, glyph) remains intact.
+- `pnpm test:unit` passes with any required test updates.
+- `pnpm test:a11y` remains green for covered routes.
+- `pnpm test:visual` remains green or records only intentional diffs.
+
+## Proposed Tests
+
+- Add or adjust tests to verify shared scaffold behavior and tag-specific
+  attributes (`<a>` vs `<button>`).
+- Verify external-anchor behavior for `target`, `rel`, and external indicator
+  rendering.
+- Run `pnpm test:unit`.
+- Run `pnpm test:a11y`.
+- Run `pnpm test:visual` and review any intentional snapshot updates.
+
+## Affected Artifacts
+
+- `src/components/cta.astro`
+- `src/pages/writing/index.astro`, only if fixture/call-site adjustments are
+  required to preserve behavior.
+- Optional helper/tests under `src/utils/*` only if implementation departs from
+  the default in-component consolidation design.
+- `tests/visual.spec.ts` and/or snapshots only if intentional rendering changes
+  occur.
+
+## Dependencies
+
+- Parent issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md`.
+- Previous sub-issue:
+  `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/29-cartouche-primary-render-path/sub-issue.md`.
+- Current component surface: `src/components/cta.astro`.
+- Current route-level regression suite: `tests/visual.spec.ts` and
+  `tests/a11y.spec.ts`.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/aar.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/aar.md
@@ -1,0 +1,22 @@
+1. Did it go as planned? [Yes / No] -- Yes; all planned sub-issues (`16`, `17`, `18`, `27`, `28`, `29`, `30`) were completed, and final regression/first-paint/performance checks passed.
+2. What changed from the parent issue plan:
+   - Added dedicated real-browser first-paint coverage (`tests/theme-first-paint.spec.ts`) and fixed boot-time favicon assignment at commit for light/system-light scenarios.
+   - Explicitly standardized active theme-control semantics on `aria-pressed` while retaining class hooks for presentation.
+   - Component variant cleanup landed with one primary render path per component, but implementation strategy varied by rubric: utility extraction for higher-behavior components (`IconButton`, `NavTile`) and in-component consolidation for lower-complexity components (`Cartouche`, `CTA`).
+   - Added route-surface contract tests for presentational slices (`tests/cartouche.spec.ts`, `tests/cta.spec.ts`) to verify behavior via public surfaces instead of internal template assertions.
+   - Final closure verification included `pnpm test:unit`, `pnpm test:a11y`, `pnpm test:visual`, `pnpm test --grep @firstpaint`, and `pnpm test:build` (performance budgets within limits).
+3. ADRs made during this parent issue (reference INDEX.md rows):
+   - None. No qualifying hard-to-reverse architectural decision required an ADR in this parent issue.
+4. New considerations or constraints surfaced:
+   - Keep Playwright suites sequential when they depend on the same managed web server to avoid transient startup conflicts.
+   - Preserve first-paint verification as a hard closure check before any future boot-path consolidation.
+   - For component consolidation work, apply one explicit leverage/locality/testability rubric per slice and document the reasoned choice to avoid implied extraction-by-default drift.
+5. Patterns across sub-issue AARs:
+   - Theme runtime work improved coherence by centralizing contract constants and reusing them across boot, interaction adapter, and tests.
+   - Interaction correctness depends on semantic state (`aria-pressed`) plus compatibility guards (`matchMedia` legacy listeners) rather than style hooks alone.
+   - Variant-path refactors are most stable when behavior is verified through caller-facing route surfaces and not through template internals.
+   - Extraction is valuable when behavioral state space is broader (`IconButton`, `NavTile`), while in-component consolidation preserves locality when decision complexity is low (`Cartouche`, `CTA`).
+6. Carry-forward -- flags to write in the cycle, notes for the PRD AAR:
+   - No new cycle-level blocking flags from this parent issue.
+   - PRD AAR should record that cycle acceptance checks passed with no visible **Theme flash** on covered routes and all automated regression suites green.
+   - PRD AAR should record performance budget status as a descriptive signal: HTML 33.96 KB / 80 KB, CSS 81.19 KB / 300 KB, JS 0.00 KB / 700 KB.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md
@@ -37,3 +37,14 @@
 - Do not remove duplicated theme boot logic merely because it looks redundant; remove or consolidate it only after proving no-**Theme flash** behavior remains intact.
 - Resolve the active theme control representation during implementation: `aria-pressed`, `data-state`, class names, or a combination that best preserves accessibility and styling clarity.
 - Resolve the first-paint verification method during implementation with a real browser path, not only DOM tests.
+
+- [ ] [29-cartouche-primary-render-path -> 30-cta-primary-render-path]
+
+  Do not assume utility extraction by default for `CTA`; apply the same
+  leverage/locality/testability rubric used in #29 and document the explicit
+  reason for either in-component consolidation or helper extraction.
+
+  Files to review:
+  - context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/30-cta-primary-render-path/sub-issue.md
+
+  (See source AAR for full context)

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md
@@ -38,7 +38,10 @@
 - Resolve the active theme control representation during implementation: `aria-pressed`, `data-state`, class names, or a combination that best preserves accessibility and styling clarity.
 - Resolve the first-paint verification method during implementation with a real browser path, not only DOM tests.
 
-- [ ] [29-cartouche-primary-render-path -> 30-cta-primary-render-path]
+- [x] [29-cartouche-primary-render-path -> 30-cta-primary-render-path]
+
+  Resolved in #30 pre-activation: CTA implementation will apply and document the
+  leverage/locality/testability rubric before choosing consolidation vs helper extraction.
 
   Do not assume utility extraction by default for `CTA`; apply the same
   leverage/locality/testability rubric used in #29 and document the explicit

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/issue.md
@@ -1,0 +1,39 @@
+# Issue #15: Theme Runtime And Component Variants
+
+## Acceptance criteria
+
+- No visible **Theme flash** is observed on `/` and `/writing` for light, dark, and system preferences during real-browser verification.
+- `pnpm test:unit` passes for the deepened theme contract and runtime adapter behavior.
+- `pnpm test:a11y` reports zero axe-core violations.
+- `pnpm test:visual` either passes unchanged or produces only intentional snapshot diffs reviewed as component cleanup.
+- Theme runtime exports are reduced to the contract needed by production code and tests.
+- Each refactored component has one primary render path unless a branch has a distinct semantic responsibility.
+- Any **Performance budget** movement is documented as a descriptive signal.
+
+## Implementation approach
+
+- Start with the canonical theme runtime contract and export boundary.
+- Preserve and verify pre-paint theme boot behavior before deleting or consolidating boot-adjacent code.
+- Align theme interaction state, document attributes, favicon updates, and tests with the contract.
+- Delete unused theme code only with deletion-test evidence that it is not protecting against **Theme flash**.
+- Collapse behavior-preserving component variant branches in focused vertical slices for `IconButton`, `NavTile`, `Cartouche`, and `CTA`.
+- Document **Performance budget** movement as a reference signal, not a hard gate, unless a later cycle changes that policy.
+- Run final unit, accessibility, visual, and first-paint verification before closing the parent issue.
+
+## Dependencies
+
+- Source PRD: `context/cycles/01-theme-runtime-and-component-variants/prd.md`.
+- Sub-PRD: `context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/sub-prd.md`.
+- Current theme runtime, boot path, interaction adapter, favicon behavior, and theme tests.
+- Current component implementations for `IconButton`, `NavTile`, `Cartouche`, and `CTA`.
+- Regression checks documented for unit, accessibility, visual, and real-browser first-paint verification.
+
+## Flags
+
+- Do not add Astro Content Collections, mantra routes, section registries, or new public pages.
+- Do not activate `SOFTWARE`, `Fotos`, or `VIDEOS`.
+- Do not redesign the visual language, typography, color palette, or navigation model.
+- Do not make performance budgets a hard gate for this cycle.
+- Do not remove duplicated theme boot logic merely because it looks redundant; remove or consolidate it only after proving no-**Theme flash** behavior remains intact.
+- Resolve the active theme control representation during implementation: `aria-pressed`, `data-state`, class names, or a combination that best preserves accessibility and styling clarity.
+- Resolve the first-paint verification method during implementation with a real browser path, not only DOM tests.

--- a/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/sub-prd.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/issues/15-theme-runtime-and-component-variants/sub-prd.md
@@ -1,0 +1,29 @@
+# Theme Runtime And Component Variants Sub-PRD
+
+> Translated to `issue.md`. This sub-PRD records the product-level intent --
+> user stories and dependencies. Update `issue.md` for ongoing technical work.
+> Update this file only if the underlying user stories themselves change.
+
+## User Stories Owned
+
+- As a returning visitor, I want my saved **Theme preference** applied before the page visibly renders so that I do not see the wrong theme flash on load.
+- As a visitor using system theme, I want the page to match my system setting on first paint and after system changes so that the site feels visually stable.
+- As a maintainer, I want one theme runtime contract so that changing theme behavior does not require auditing inline scripts, utility exports, CSS selectors, and tests separately.
+- As a maintainer, I want component variants expressed in one render path where practical so that I can adjust button, tile, CTA, and cartouche behavior without mentally diffing duplicated JSX.
+- As a maintainer, I want performance budgets documented as reference signals so that I can record trade-offs without treating every size movement as a blocker.
+
+## Encounter Statements
+
+- When the home surface loads in dark preference, the first visible frame is already dark.
+- When the writing section loads in light preference, the first visible frame is already light.
+- When the visitor changes the theme control, the document attributes, favicon, active control state, and rendered colors stay coherent.
+- When a component variant changes, its structure remains recognizable and the visual regression check shows whether the change is intentional.
+- When a build exceeds the current performance reference, the cycle records the movement instead of stopping unrelated refactor work by default.
+
+## Directional Dependencies
+
+- Theme runtime contract work must precede theme boot and interaction cleanup so those adapters can depend on one small canonical surface.
+- Theme boot verification must precede deletion of apparently duplicated theme code because no-**Theme flash** behavior is the primary quality bar.
+- Theme interaction alignment depends on the runtime contract and must preserve coherent document attributes, favicon target selection, and active control state.
+- Component variant cleanup can proceed after baseline theme behavior is protected because visual snapshots may otherwise conflate theme and markup changes.
+- Performance budget documentation can proceed independently, but final cycle closure depends on recording any observed movement as a descriptive signal.

--- a/context/cycles/01-theme-runtime-and-component-variants/pitch.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/pitch.md
@@ -1,0 +1,7 @@
+# Theme Runtime And Component Variants Pitch
+
+Problem: Future maintainers cannot safely simplify theme and component internals because the current code protects against theme flash through duplicated runtime paths and repeated component branches.
+Who: Maintainers of the personal website who need to improve the current codebase before adding new public sections.
+Gap: The existing implementation works, but its theme behavior requires cross-file reasoning and its component variants require mentally diffing duplicated markup.
+Distinction: This cycle deepens the current static site without introducing new content models, routes, or product surfaces.
+Form / access surface: A refactor cycle for the Astro source, documented under `context/cycles/01-theme-runtime-and-component-variants/`.

--- a/context/cycles/01-theme-runtime-and-component-variants/prd.md
+++ b/context/cycles/01-theme-runtime-and-component-variants/prd.md
@@ -1,0 +1,84 @@
+# Theme Runtime And Component Variants PRD
+
+## Focus
+
+Deepen the existing theme runtime and component variant surfaces so the personal website can be refactored without reintroducing theme flash, duplicated theme semantics, or duplicated component markup.
+
+## Intentions
+
+- Preserve the visitor's selected **Theme preference** from the first paint through client-side initialization.
+- Make the absence of **Theme flash** the primary quality bar for all theme changes.
+- Turn theme behavior into a small, explicit runtime contract with thin boot and interaction adapters.
+- Simplify presentational components by moving variant differences into named class and attribute decisions instead of duplicated render branches.
+- Keep the cycle focused on codebase depth before adding new sections, content collections, or prototype-driven features.
+- Treat the **Performance budget** as a descriptive reference signal during this cycle, not as a hard blocker.
+
+## Goals
+
+- Create one canonical theme runtime contract for valid preferences, storage key, actual theme resolution, document attributes, and favicon target selection.
+- Keep or improve the current no-flash theme boot behavior for light, dark, and system preferences.
+- Reduce the public export surface of the theme runtime to the smallest interface needed by boot, interaction, and tests.
+- Remove theme code that has no current observable responsibility only when tests and first-paint checks prove it is not protecting against **Theme flash**.
+- Refactor `IconButton`, `NavTile`, `Cartouche`, and `CTA` toward single render paths with explicit variants where the existing markup branches are behavior-preserving duplicates.
+- Update context and cycle docs to state that performance budgets are reference baselines unless a later cycle makes them imperative.
+- Preserve the current **Accessibility baseline** on `/` and `/writing`.
+- Preserve the current **Visual baseline** except for intentional, reviewed snapshot updates caused by behavior-preserving component cleanup.
+
+## Non-goals
+
+- Do not add Astro Content Collections, mantra routes, section registries, or new public pages.
+- Do not activate `SOFTWARE`, `Fotos`, or `VIDEOS`.
+- Do not redesign the visual language, typography, color palette, or navigation model.
+- Do not make performance budgets a hard gate for this cycle.
+- Do not remove duplicated theme boot logic merely because it looks redundant; remove or consolidate it only after proving the no-**Theme flash** behavior remains intact.
+- Do not use the unrevealed prototype as an inferred product direction.
+
+## User stories
+
+- As a returning visitor, I want my saved **Theme preference** applied before the page visibly renders so that I do not see the wrong theme flash on load.
+- As a visitor using system theme, I want the page to match my system setting on first paint and after system changes so that the site feels visually stable.
+- As a maintainer, I want one theme runtime contract so that changing theme behavior does not require auditing inline scripts, utility exports, CSS selectors, and tests separately.
+- As a maintainer, I want component variants expressed in one render path where practical so that I can adjust button, tile, CTA, and cartouche behavior without mentally diffing duplicated JSX.
+- As a maintainer, I want performance budgets documented as reference signals so that I can record trade-offs without treating every size movement as a blocker.
+
+## Encounter statements
+
+- When the home surface loads in dark preference, the first visible frame is already dark.
+- When the writing section loads in light preference, the first visible frame is already light.
+- When the visitor changes the theme control, the document attributes, favicon, active control state, and rendered colors stay coherent.
+- When a component variant changes, its structure remains recognizable and the visual regression check shows whether the change is intentional.
+- When a build exceeds the current performance reference, the cycle records the movement instead of stopping unrelated refactor work by default.
+
+## Constraints and assumptions
+
+- The site remains an Astro static site using Tailwind CSS.
+- The theme boot path may still need an inline script or equivalent pre-paint mechanism; avoiding **Theme flash** is more important than eliminating apparent duplication.
+- The current visual and accessibility checks cover `/` and `/writing` across supported theme preferences.
+- Browser first-paint behavior must be checked with a real browser path, not only Vitest DOM tests.
+- Component variant cleanup should be behavior-preserving and should not introduce a new styling framework.
+- **Performance budget** changes are observed and documented, but they are not cycle-stopping by themselves.
+
+## Success metrics
+
+- No visible **Theme flash** is observed on `/` and `/writing` for light, dark, and system preferences during real-browser verification.
+- `pnpm test:unit` passes for the deepened theme contract and runtime adapter behavior.
+- `pnpm test:a11y` reports zero axe-core violations.
+- `pnpm test:visual` either passes unchanged or produces only intentional snapshot diffs reviewed as component cleanup.
+- Theme runtime exports are reduced to the contract needed by production code and tests.
+- Each refactored component has one primary render path unless a branch has a distinct semantic responsibility.
+- Any performance-budget movement is documented as a descriptive signal.
+
+## Success signals
+
+- Future theme changes can be reviewed by reading a small contract plus boot/interaction adapters.
+- Maintainers can explain which code exists specifically to prevent **Theme flash**.
+- Deleted theme code has an explicit deletion-test note showing why it was safe to remove.
+- Component variants are named and localized, making visual changes easier to review.
+- Product context no longer implies that the performance budget blocks all refactor progress.
+
+## Open questions
+
+- RESOLVE THROUGH IMPLEMENTATION: What is the smallest inline or pre-paint theme boot code that preserves no-**Theme flash** behavior?
+- RESOLVE THROUGH IMPLEMENTATION: Which currently duplicated component branches are truly behavior-preserving and safe to collapse?
+- RESOLVE THROUGH IMPLEMENTATION: Should active theme control state be represented by `aria-pressed`, `data-state`, a class, or a combination that best preserves accessibility and styling clarity?
+- RESOLVE THROUGH IMPLEMENTATION: What verification method should be used to make first-paint theme stability visible enough to trust during this cycle?

--- a/context/product.md
+++ b/context/product.md
@@ -1,0 +1,58 @@
+# Amet Alvirde Product Frame
+
+## Elevator Pitch
+
+Problem: Amet needs a small, coherent public home for writing, software, photos, videos, and links to longer-form consciousness work.
+Who: Visitors who want to understand Amet Alvirde through his public creative and technical work.
+Gap: Social profiles and external publishing surfaces fragment the identity, navigation, and tone of the work.
+Distinction: The site presents Amet as a polymath human experience through a restrained, personal, Spanish-first interface rather than a portfolio template or feed.
+Form / access surface: A static Astro website at `ametalvirde.com` with a home navigation surface and section pages.
+
+## Intentions
+
+- Preserve Amet's public identity as the organizing center of the website.
+- Keep the site fast, accessible, and visually stable across supported themes and viewports.
+- Let new sections grow from the home navigation without weakening the site's personal tone.
+- Favor durable, readable content over high-maintenance presentation mechanics.
+
+## Goals
+
+- Maintain a coherent home surface that routes visitors to available and planned sections.
+- Keep writing available as a first-class section.
+- Support light, dark, and system theme preferences without visible boot-time inconsistency.
+- Protect the current regression baseline with visual, accessibility, Lighthouse, build-budget, unit, format, and lint checks, while treating performance budgets as descriptive reference signals unless a cycle explicitly makes them blocking.
+
+## Access Surface
+
+- Public visitors enter through `/`.
+- Writing is available at `/writing`.
+- Planned sections are represented from the home navigation but remain disabled until ready.
+- External long-form consciousness work is reached from the writing page through the public Obsidian map link.
+
+## Work Boundaries
+
+- This project owns the public website source, generated static site behavior, local component system, theme handling, and regression checks.
+- This project does not own external publishing platforms, social networks, analytics products, or the content lifecycle of linked external surfaces.
+- Disabled sections should communicate future direction without creating dead navigable pages.
+
+## Generative Core
+
+The generative core is a personal navigation surface that lets Amet add public facets of his work while keeping identity, accessibility, theme behavior, and performance coherent.
+
+## Coherence Signals
+
+- The first viewport clearly identifies Amet Alvirde.
+- The interface remains Spanish-first unless a specific section intentionally chooses otherwise.
+- Navigation labels and section copy feel personal, not generic.
+- Theme controls work consistently before and after client-side initialization.
+- The first paint uses the intended theme without a visible theme flash.
+- Visual changes are intentional and reflected in approved snapshots.
+- Lighthouse and performance budget movement is recorded as a product signal; it should inform trade-offs without automatically blocking refactor work.
+
+## Constraints
+
+- The site is built with Astro and Tailwind CSS.
+- The current automated check surface is documented in `tests/README.md`.
+- Public pages must preserve automated accessibility checks with zero axe-core violations.
+- Static output is measured against configured performance budgets as a descriptive baseline; exceeding a budget requires an explicit note, not an automatic stop.
+- New SDP cycles should be created lazily under `context/cycles/` only when there is an actual feature, refactor, or closure target.

--- a/context/refactor-opportunities-2026-05-08.md
+++ b/context/refactor-opportunities-2026-05-08.md
@@ -1,0 +1,300 @@
+# Refactor Opportunity Report
+
+Date: 2026-05-08
+
+## SDP State
+
+The repository is a single-context SDP project: `context/product.md` and
+`context/ubiquitous-language.md` exist, with no `context/context-map.md`.
+There are no active cycle folders and no ADR index. Per `sdp-orchestrator`, the
+next move is Flow B refactor exploration, not immediate cycle scaffolding.
+
+Per `sdp-refactor`, this report stops at numbered candidates. After a candidate
+is selected, the next step is to write a refactor-cycle pitch/PRD for that one
+candidate under `context/cycles/`.
+
+## Product Pressure
+
+The product frame says the generative core is "a personal navigation surface"
+that can add public facets while keeping identity, accessibility, theme
+behavior, and performance coherent. The current codebase already protects those
+qualities with visual, accessibility, Lighthouse, performance-budget, unit,
+format, and lint checks. The refactor opportunities below focus on making those
+qualities easier to preserve as new sections are added.
+
+No ADR conflicts were found.
+
+## Candidate 1: Deepen Theme Preference Into A Single Runtime Contract
+
+Affected artifacts:
+
+- `src/layouts/base-layout.astro`
+- `src/utils/theme-manager.ts`
+- `src/utils/theme-manager.test.ts`
+- `src/components/theme-controls.astro`
+- `src/components/monogram-display.astro`
+- `src/styles/global.css`
+- `tests/visual.spec.ts`
+- `tests/a11y.spec.ts`
+
+Concrete friction:
+
+- Theme boot behavior is split across inline HTML (`base-layout.astro` lines
+  26-57), the client manager (`theme-manager.ts` lines 1-297), CSS selectors
+  (`global.css` lines 223-235), monogram display rules, and test init scripts.
+- The same concepts recur in several places: valid preferences, the `theme`
+  localStorage key, favicon switching, `matchMedia`, `data-theme`, and
+  `data-theme-preference`.
+- The interface around theme controls is nearly as large as the implementation:
+  the manager exports several internals so tests can reach behavior that is not
+  otherwise represented as a small domain contract.
+- The inline script and the hydrated manager both register system-theme change
+  listeners. They are currently compatible, but future changes need cross-file
+  reasoning.
+
+Deletion test:
+
+- Delete only the inline script: boot-time theme stability is at risk.
+- Delete only the hydrated manager: the initial theme can still apply, but the
+  visitor cannot change theme.
+- Delete only the CSS active selector block: button state still changes in JS,
+  but visual state depends on the class/CSS interaction.
+- Result: theme behavior cannot be deleted or reasoned about at one deepened
+  interface. It requires bouncing through layout, utility code, CSS, component
+  IDs, and tests.
+
+Proposed change:
+
+- Introduce a small theme contract module that owns constants, preference
+  validation, actual-theme resolution, document attribute application, and
+  favicon target selection.
+- Keep the inline boot script minimal and explicitly generated from or mirrored
+  against that contract, with a test that catches drift.
+- Turn the client manager into an adapter for DOM controls and system-change
+  events rather than the primary owner of theme semantics.
+- Prefer explicit `aria-pressed`/`data-state` button state over global ID-based
+  CSS overrides where practical.
+
+Expected gain in locality and leverage:
+
+- Theme changes become local to one contract plus thin adapters.
+- Visual boot stability remains protected without duplicating the whole logic
+  engine in the layout.
+- Future theme or asset changes have a smaller blast radius.
+
+Test improvement at the deepened interface:
+
+- Fast unit tests for the pure preference/state contract.
+- DOM unit tests only for the adapter behavior.
+- One Playwright interaction test for the real controls across light, dark, and
+  system, instead of relying only on screenshot/a11y setup.
+
+## Candidate 2: Extract A Section Registry For The Personal Navigation Surface
+
+Affected artifacts:
+
+- `src/pages/index.astro`
+- `src/pages/writing/index.astro`
+- `src/components/nav-tile.astro`
+- `src/components/cta.astro`
+- `tests/visual.spec.ts`
+- `tests/a11y.spec.ts`
+- `lighthouserc.cjs`
+- `scripts/check-perf-budget.mjs`
+- `context/product.md`
+- `context/ubiquitous-language.md`
+
+Concrete friction:
+
+- Domain concepts such as Section, Writing section, Planned section, and
+  External surface exist in context, but the executable source does not have a
+  section model.
+- The home surface hardcodes section tiles directly in
+  `src/pages/index.astro` lines 18-46.
+- The writing page hardcodes section content and the external consciousness
+  surface directly in `src/pages/writing/index.astro` lines 21-52.
+- Regression checks repeat route knowledge in visual tests, accessibility
+  tests, Lighthouse config, and the performance budget script.
+
+Deletion test:
+
+- Delete a planned tile from the home page: no central model records whether
+  that public facet is intentionally planned or removed.
+- Delete `/writing` from the Playwright page arrays: Lighthouse and performance
+  checks still know about it separately.
+- Delete the Obsidian URL from the writing page: no domain object records the
+  external surface relationship.
+- Result: the generative core is present in the product language but shallow in
+  code.
+
+Proposed change:
+
+- Add a typed section registry that represents section slug, label, description,
+  status (`available` or `planned`), route, external surfaces, and regression
+  coverage metadata.
+- Render the home tiles from that registry.
+- Let tests consume a shared route matrix derived from the registry, while
+  keeping test-specific viewport/theme configuration in test code.
+- Keep page content close to the page for now unless the writing section needs
+  multiple entries.
+
+Expected gain in locality and leverage:
+
+- Adding a public facet becomes one coherent change instead of page, tests,
+  Lighthouse, and budget updates in separate places.
+- The code gains an executable representation of the domain language already in
+  `context/ubiquitous-language.md`.
+- Planned sections stay intentional without creating empty routes.
+
+Test improvement at the deepened interface:
+
+- Unit test the registry invariants: each available section has a route, each
+  planned section has no navigable route, and each covered route appears in the
+  app-level check matrix.
+- Existing visual and a11y tests remain the acceptance surface for rendered
+  behavior.
+
+## Candidate 3: Consolidate Component Surface Styling Into Explicit Variants
+
+Affected artifacts:
+
+- `src/components/icon-button.astro`
+- `src/components/nav-tile.astro`
+- `src/components/cta.astro`
+- `src/components/cartouche.astro`
+- `src/components/Navigation.astro`
+- `src/components/Footer.astro`
+- `src/styles/global.css`
+
+Concrete friction:
+
+- Several components carry long Tailwind class strings with repeated structure:
+  border, background, transition, hover, focus, spacing, uppercase, and tracking
+  patterns.
+- `IconButton` has variant strings that duplicate most of their class content
+  (`icon-button.astro` lines 27-34).
+- `NavTile` branches disabled and enabled markup, duplicating layout structure
+  while changing behavior and trailing affordance (`nav-tile.astro` lines
+  19-54).
+- `Cartouche` branches hero and section markup, duplicating identity lockup
+  structure (`cartouche.astro` lines 14-38).
+- `global.css` says site-specific styles live in `site.css`, but there is no
+  `site.css`; site-specific component state currently lives in global selectors
+  with `!important` (`global.css` lines 223-235).
+
+Deletion test:
+
+- Delete a single utility class from one component: the same visual rule may
+  still exist elsewhere, but no component variant contract tells whether the
+  difference is intentional.
+- Delete the global active button override: active-state rendering changes even
+  though component code still adds `icon-button--active`.
+- Delete one branch of `NavTile` or `Cartouche`: the other branch is not a
+  reusable primitive; behavior and visual surface are coupled.
+- Result: the component system is visually coherent but shallow. The styling
+  interface is encoded as repeated strings instead of named variants.
+
+Proposed change:
+
+- Introduce explicit component variants using `class:list`, small helper maps,
+  or `@layer components` classes for stable primitives such as interactive
+  surface, icon button, nav tile, identity lockup, and CTA.
+- Replace ID-based active styling with component-owned state attributes.
+- Keep Tailwind as the styling engine; the refactor is about local interfaces,
+  not a styling framework change.
+
+Expected gain in locality and leverage:
+
+- Visual language changes become edits to variants rather than hunts through
+  long class strings.
+- New sections can reuse the same small component vocabulary without copying
+  markup.
+- The visual baseline remains useful because screenshots catch intentional
+  variant changes instead of incidental class-string drift.
+
+Test improvement at the deepened interface:
+
+- Add a small rendered fixture or page-level coverage for component states:
+  enabled/disabled nav tile, active/inactive icon button, hero/section
+  cartouche.
+- Keep full-page snapshots as the regression baseline.
+
+## Candidate 4: Make Regression Coverage And Budgets A First-Class Check Matrix
+
+Affected artifacts:
+
+- `tests/visual.spec.ts`
+- `tests/a11y.spec.ts`
+- `lighthouserc.cjs`
+- `scripts/check-perf-budget.mjs`
+- `tests/README.md`
+- `package.json`
+
+Concrete friction:
+
+- Covered pages are repeated in `tests/visual.spec.ts`, `tests/a11y.spec.ts`,
+  `lighthouserc.cjs`, and `scripts/check-perf-budget.mjs`.
+- `scripts/check-perf-budget.mjs` hardcodes only `index.html` and
+  `writing/index.html` for HTML weight, so future available sections can be
+  missed unless the script is manually updated.
+- `tests/README.md` documents 50 KB HTML, 20 KB CSS, and 10 KB JS budgets, but
+  `scripts/check-perf-budget.mjs` enforces 80 KB HTML, 300 KB CSS, and 700 KB
+  JS. The documented baseline and executable check have drifted.
+- `package.json` masks Lighthouse command failure with `|| true`, which makes
+  the check less authoritative than the documented regression gate.
+
+Deletion test:
+
+- Delete `/writing` from one test file: other check surfaces still include it,
+  so coverage intent is fragmented.
+- Delete a route from the performance script: the build still passes while the
+  route may no longer be budgeted.
+- Delete the README budget values: executable checks still run, but maintainers
+  lose the stated baseline.
+- Result: regression coverage is broad, but the coverage model is not deep.
+
+Proposed change:
+
+- Create a shared check matrix for public routes and supported theme
+  preferences.
+- Update visual and a11y tests to consume that matrix.
+- Move performance budgets into a small config object consumed by
+  `scripts/check-perf-budget.mjs` and documented from the same source, or at
+  minimum align the README and script.
+- Decide whether Lighthouse should fail the pipeline on assertion failures and
+  only filter the GitHub-token noise without swallowing the command status.
+
+Expected gain in locality and leverage:
+
+- Adding an available route becomes one update to the check matrix.
+- Budget drift becomes visible and intentional.
+- The regression surface better matches the product promise: fast, accessible,
+  visually stable, and covered across public surfaces.
+
+Test improvement at the deepened interface:
+
+- Unit test the route-to-built-file mapping used by the budget script.
+- Keep Playwright and Lighthouse as app-level checks, now driven by shared
+  coverage intent.
+
+## Recommendation
+
+If the next cycle should reduce the most immediate implementation risk, choose
+Candidate 1. Theme preference is a named product goal, crosses the most runtime
+boundaries, and already has enough tests to refactor safely.
+
+If the next cycle should prepare the site for more public facets, choose
+Candidate 2. It aligns most directly with the generative core and will make the
+next section addition cleaner.
+
+If the next cycle should harden the project gate before more feature work,
+choose Candidate 4. It contains a concrete drift between documented and
+enforced budgets and improves confidence in every later refactor.
+
+Candidate 3 is useful, but it has the highest chance of creating snapshot churn
+without changing product leverage unless paired with a section or theme cycle.
+
+## Candidate Selection Needed
+
+Select one candidate to pursue as the SDP refactor cycle. The next step is to
+load `sdp-pitch-prd` and write the cycle pitch/PRD for the chosen candidate.

--- a/context/ubiquitous-language.md
+++ b/context/ubiquitous-language.md
@@ -1,0 +1,70 @@
+# Personal Website
+
+> Canonical glossary for this context -- terms, relationships, example dialogue. Product pitch, goals, and constraints live in `product.md`.
+
+## Public Identity
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Amet Alvirde** | The public person and identity represented by the website. | brand, portfolio owner |
+| **Personal website** | The static public site that gathers Amet's public identity, navigation, and owned presentation. | portfolio, blog |
+| **Public identity** | The coherent expression of Amet's name, tone, work facets, and presentation across the site. | branding |
+| **Human experience** | The self-description used by the site to frame Amet as a person rather than only a professional role. | persona |
+| **Consciousness work** | Amet's reflective writing and mapped thought around consciousness, peace, and lived experience. | self-help content |
+
+## Site Surfaces
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Home surface** | The root page that introduces Amet and routes visitors to available or planned sections. | landing page |
+| **Section** | A named area of the website that represents one facet of Amet's public work. | category |
+| **Writing section** | The section that presents Amet's written consciousness work on the site. | blog |
+| **Planned section** | A section shown in navigation as future direction but intentionally unavailable to visitors. | coming soon page |
+| **External surface** | A public destination linked from the website but not owned by this codebase. | integration |
+
+## Experience Quality
+
+| Term | Definition | Aliases to avoid |
+| --- | --- | --- |
+| **Theme preference** | The visitor's selected light, dark, or system visual mode. | color mode |
+| **Theme flash** | A visible mismatch between the intended theme and the rendered page during initial load or navigation. | FOUC, loading flash |
+| **Visual baseline** | The approved screenshot set that represents intentional layout and theme behavior. | snapshot truth |
+| **Accessibility baseline** | The current expectation that automated axe-core checks report zero violations on covered pages. | a11y pass |
+| **Performance budget** | The configured reference limits for generated HTML, CSS, and JavaScript output. | hard bundle gate |
+| **Regression check** | An automated check that protects known behavior, layout, accessibility, performance, or code quality. | test |
+
+## Relationships
+
+- A **Personal website** represents exactly one **Amet Alvirde**.
+- A **Home surface** belongs to the **Personal website**.
+- A **Section** belongs to the **Personal website**.
+- A **Writing section** is a **Section**.
+- A **Planned section** is a **Section**.
+- An **External surface** may be linked from a **Section**.
+- A **Theme preference** affects the **Home surface** and every **Section**.
+- A **Theme flash** may violate a visitor's intended **Theme preference**.
+- A **Regression check** may protect a **Visual baseline**, **Accessibility baseline**, or **Performance budget**.
+
+## Example Dialogue
+
+> **Dev:** "Should the home page behave like a marketing landing page?"
+> **Domain expert:** "No. The **Home surface** should introduce **Amet Alvirde** and route visitors through the **Personal website**."
+
+> **Dev:** "Can we turn the disabled software tile into an empty route?"
+> **Domain expert:** "Not yet. It remains a **Planned section** until there is real content or a defined cycle."
+
+> **Dev:** "Is the Obsidian map part of this product?"
+> **Domain expert:** "It is an **External surface** linked from the **Writing section**, not owned by this codebase."
+
+> **Dev:** "Can a visual tweak ship without updating screenshots?"
+> **Domain expert:** "Only if it preserves the **Visual baseline**; intentional visual changes must update it."
+
+> **Dev:** "Can the page briefly render light before switching to dark?"
+> **Domain expert:** "No. A **Theme flash** breaks the expected **Theme preference** experience."
+
+> **Dev:** "Should a performance budget warning stop every refactor?"
+> **Domain expert:** "No. A **Performance budget** is a reference signal unless the active cycle makes it a hard gate."
+
+## Flagged Ambiguities
+
+- "writing" can refer to on-site content or external consciousness work -- resolved: use **Writing section** for the on-site route and **Consciousness work** or **External surface** for linked material.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amet-alvirde",
   "type": "module",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",

--- a/src/components/cartouche.astro
+++ b/src/components/cartouche.astro
@@ -9,31 +9,27 @@ interface Props {
 
 const { subtitle, variant = "hero", monogramFill } = Astro.props as Props;
 const isHero = variant === "hero";
+const containerClass = isHero
+  ? "flex items-center justify-between border-2 border-accent-as-surface bg-accent-as-surface text-accent-as-surface-foreground no-underline transition-all duration-150 w-full relative gap-4 py-8 px-4 border-t-2 cursor-default mb-2 pointer-events-none touch-none md:py-10"
+  : "flex items-center justify-between text-accent no-underline transition-all duration-150 w-full relative gap-4 py-4 cursor-default mb-2 pointer-events-none touch-none pr-2 md:py-10 md:pr-1";
+const subtitleClass = isHero
+  ? "text-base md:text-lg tracking-wider text-accent-as-surface-foreground font-bold"
+  : "text-base md:text-lg tracking-wider text-accent font-bold font-mono uppercase";
+const monogramFillValue = isHero ? undefined : monogramFill;
 ---
 
-{isHero ? (
-  <div class="flex items-center justify-between border-2 border-accent-as-surface bg-accent-as-surface text-accent-as-surface-foreground no-underline transition-all duration-150 w-full relative gap-4 py-8 px-4 border-t-2 cursor-default mb-2 pointer-events-none touch-none md:py-10">
-    <div class="flex flex-col gap-1.5 flex-1">
-      <h1 class="text-lg xs:text-xl sm:text-2xl md:text-3xl font-bold tracking-wider uppercase leading-tight">
-        Amet Alvirde
-      </h1>
-      <p class="text-base md:text-lg tracking-wider text-accent-as-surface-foreground font-bold">
-        {subtitle}
-      </p>
-    </div>
-    <MonogramDisplay inline forceDark />
+<div
+  class={containerClass}
+  data-cartouche="true"
+  data-cartouche-variant={variant}
+>
+  <div class="flex flex-col gap-1.5 flex-1">
+    <h1 class="text-lg xs:text-xl sm:text-2xl md:text-3xl font-bold tracking-wider uppercase leading-tight">
+      Amet Alvirde
+    </h1>
+    <p class={subtitleClass}>
+      {subtitle}
+    </p>
   </div>
-) : (
-  <div class="flex items-center justify-between text-accent no-underline transition-all duration-150 w-full relative gap-4 py-4 cursor-default mb-2 pointer-events-none touch-none pr-2 md:py-10 md:pr-1">
-    <div class="flex flex-col gap-1.5 flex-1">
-      <h1 class="text-lg xs:text-xl sm:text-2xl md:text-3xl font-bold tracking-wider uppercase leading-tight">
-        Amet Alvirde
-      </h1>
-      <p class="text-base md:text-lg tracking-wider text-accent font-bold font-mono uppercase">
-        {subtitle}
-      </p>
-    </div>
-    <MonogramDisplay inline forceDark fill={monogramFill} />
-  </div>
-)}
-
+  <MonogramDisplay inline forceDark fill={monogramFillValue} />
+</div>

--- a/src/components/cta.astro
+++ b/src/components/cta.astro
@@ -17,30 +17,32 @@ const {
   ...attrs
 } = Astro.props as Props;
 
+const isLink = as === "a";
 const baseClasses =
   "inline-flex items-center justify-center py-3 px-4 border-2 border-accent-as-surface bg-accent-as-surface text-accent-as-surface-foreground text-sm font-medium uppercase tracking-widest transition-all duration-150 cursor-pointer no-underline [@media(hover:hover)]:hover:bg-foreground [@media(hover:hover)]:hover:text-canvas [@media(hover:hover)]:hover:border-foreground active:bg-foreground active:text-canvas active:border-foreground focus-visible:outline-2 focus-visible:outline-accent-as-surface focus-visible:outline-offset-2";
 
 const classes = [baseClasses, extraClass].filter(Boolean).join(" ");
+const tagSpecificAttrs = isLink
+  ? {
+      href,
+      target: external ? "_blank" : undefined,
+      rel: external ? "noopener noreferrer" : undefined,
+    }
+  : { type: "button" };
+const Element = as;
 ---
 
-{as === "a" ? (
-  <a
-    href={href}
-    target={external ? "_blank" : undefined}
-    rel={external ? "noopener noreferrer" : undefined}
-    class={classes}
-    {...attrs}
-  >
-    {label}
-    {external && (
-      <span aria-hidden="true" class="ml-1">
-        ↗
-      </span>
-    )}
-  </a>
-) : (
-  <button type="button" class={classes} {...attrs}>
-    {label}
-  </button>
-)}
-
+<Element
+  class={classes}
+  data-cta="true"
+  data-cta-as={as}
+  {...tagSpecificAttrs}
+  {...attrs}
+>
+  {label}
+  {isLink && external && (
+    <span aria-hidden="true" class="ml-1">
+      ↗
+    </span>
+  )}
+</Element>

--- a/src/components/icon-button.astro
+++ b/src/components/icon-button.astro
@@ -1,4 +1,9 @@
 ---
+import {
+  getIconButtonClasses,
+  type IconButtonVariant,
+} from "../utils/icon-button-contract";
+
 interface Props {
   as?: "button" | "a";
   href?: string;
@@ -8,7 +13,7 @@ interface Props {
   type?: "button" | "submit" | "reset";
   /** When "inherit", uses parent bg/foreground and blends (e.g. inside footer) */
   /** When "borderless", no visible border but same hover as default */
-  variant?: "default" | "inherit" | "borderless";
+  variant?: IconButtonVariant;
   // Allow passing through any additional HTML attributes
   [key: string]: unknown;
 }
@@ -24,42 +29,20 @@ const {
   ...attrs
 } = Astro.props as Props;
 
-const defaultClasses =
-  "icon-button inline-flex items-center justify-center p-2 border-2 border-border bg-canvas text-foreground transition-all duration-150 cursor-pointer [@media(hover:hover)]:hover:bg-accent-as-surface [@media(hover:hover)]:hover:text-accent-as-surface-foreground [@media(hover:hover)]:hover:border-accent-as-surface focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2";
-
-const inheritClasses =
-  "icon-button inline-flex items-center justify-center p-2 border-2 border-transparent bg-transparent text-inherit transition-all duration-150 cursor-pointer [@media(hover:hover)]:hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-currentColor";
-
-const borderlessClasses =
-  "icon-button inline-flex items-center justify-center p-2 border-0 bg-canvas text-foreground transition-all duration-150 cursor-pointer [@media(hover:hover)]:hover:bg-accent-as-surface [@media(hover:hover)]:hover:text-accent-as-surface-foreground focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2";
-
-const baseClasses =
-  variant === "inherit"
-    ? inheritClasses
-    : variant === "borderless"
-      ? borderlessClasses
-      : defaultClasses;
-const classes = [baseClasses, extraClass].filter(Boolean).join(" ");
+const classes = getIconButtonClasses(variant, extraClass);
+const resolvedTitle = title ?? ariaLabel;
+const sharedAttrs = {
+  "aria-label": ariaLabel,
+  title: resolvedTitle,
+  class: classes,
+};
 ---
 {as === "a" ? (
-  <a
-    href={href}
-    aria-label={ariaLabel}
-    title={title ?? ariaLabel}
-    class={classes}
-    {...attrs}
-  >
+  <a href={href} {...sharedAttrs} {...attrs}>
     <slot />
   </a>
 ) : (
-  <button
-    type={type}
-    aria-label={ariaLabel}
-    title={title ?? ariaLabel}
-    class={classes}
-    {...attrs}
-  >
+  <button type={type} {...sharedAttrs} {...attrs}>
     <slot />
   </button>
 )}
-

--- a/src/components/nav-tile.astro
+++ b/src/components/nav-tile.astro
@@ -1,4 +1,6 @@
 ---
+import { getNavTileState } from "../utils/nav-tile-contract";
+
 interface Props {
   href: string;
   title: string;
@@ -14,42 +16,27 @@ const {
   disabled = false,
   disabledLabel = "PRONTO",
 } = Astro.props as Props;
+
+const tileState = getNavTileState(disabled);
 ---
 
-{disabled ? (
-  <a
-    href={href}
-    class="flex items-center justify-between border-2 border-t-0 !border-border bg-canvas text-foreground no-underline transition-all duration-150 w-full relative gap-4 py-6 px-5 md:py-7 md:px-6 cursor-not-allowed pointer-events-none [-webkit-tap-highlight-color:transparent]"
-    aria-disabled="true"
-  >
-    <div class="flex flex-col gap-1.5 flex-1">
-      <span class="text-sm font-medium tracking-widest uppercase leading-tight text-muted">
-        {title}
-      </span>
-      <span class="text-xs tracking-wide text-muted">
-        {description}
-      </span>
-    </div>
-    <span class="text-xs uppercase tracking-[0.2em] font-semibold text-muted">
+<a href={href} class={tileState.containerClass} aria-disabled={tileState.ariaDisabled}>
+  <div class="flex flex-col gap-1.5 flex-1">
+    <span class={tileState.titleClass}>
+      {title}
+    </span>
+    <span class="text-xs tracking-wide text-muted">
+      {description}
+    </span>
+  </div>
+
+  {tileState.showsDisabledLabel ? (
+    <span class={tileState.trailingClass}>
       {disabledLabel}
     </span>
-  </a>
-) : (
-  <a
-    href={href}
-    class="flex items-center justify-between border-2 border-border border-t-2 bg-surface text-foreground no-underline transition-all duration-150 w-full relative gap-4 py-7 px-5 md:py-8 md:px-6 [@media(hover:hover)]:hover:border-accent active:border-accent focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 [-webkit-tap-highlight-color:transparent]"
-  >
-    <div class="flex flex-col gap-1.5 flex-1">
-      <span class="text-sm font-medium tracking-widest uppercase leading-tight text-foreground">
-        {title}
-      </span>
-      <span class="text-xs tracking-wide text-muted">
-        {description}
-      </span>
-    </div>
-    <span class="flex items-center shrink-0">
+  ) : (
+    <span class={tileState.trailingClass}>
       <i class="ph ph-arrow-right text-xl" aria-hidden="true"></i>
     </span>
-  </a>
-)}
-
+  )}
+</a>

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -4,6 +4,7 @@ import Footer from "../components/Footer.astro";
 import {
   THEME_PREFERENCES,
   THEME_STORAGE_KEY,
+  FAVICON_SELECTOR,
   FAVICON_TARGETS,
 } from "../utils/theme-runtime-contract";
 
@@ -33,12 +34,14 @@ const {
 			define:vars={{
 				themeStorageKey: THEME_STORAGE_KEY,
 				themePreferences: THEME_PREFERENCES,
+				faviconSelector: FAVICON_SELECTOR,
 				faviconTargets: FAVICON_TARGETS,
 			}}
 		>
 			(function () {
 				const THEME_KEY = themeStorageKey;
 				const VALID_PREFERENCES = themePreferences;
+				const FAVICON_LINK_SELECTOR = faviconSelector;
 				const FAVICONS = faviconTargets;
 				const stored = (function () { try { return localStorage.getItem(THEME_KEY); } catch { return null; } })();
 				const preference = VALID_PREFERENCES.includes(stored) ? stored : 'system';
@@ -61,13 +64,13 @@ const {
 				}
 
 				const setFavicon = () => {
-					const favicon = document.querySelector('link[rel="icon"]:not([media])');
+					const favicon = document.querySelector(FAVICON_LINK_SELECTOR);
 					if (favicon) {
 						const isDark = document.documentElement.classList.contains('dark');
 						favicon.href = isDark ? FAVICONS.dark : FAVICONS.light;
 					}
 				};
-				document.readyState === 'loading' ? document.addEventListener('DOMContentLoaded', setFavicon) : setFavicon();
+				setFavicon();
 			})();
 		</script>
 		<!-- Open Graph / Facebook -->

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -1,6 +1,11 @@
 ---
 import "../styles/global.css";
 import Footer from "../components/Footer.astro";
+import {
+  THEME_PREFERENCES,
+  THEME_STORAGE_KEY,
+  FAVICON_TARGETS,
+} from "../utils/theme-runtime-contract";
 
 interface Props {
   title?: string;
@@ -23,11 +28,20 @@ const {
 		<meta name="generator" content={Astro.generator} />
 		<meta name="description" content={description}>
 		<title>{title}</title>
-		<script is:inline>
+		<script
+			is:inline
+			define:vars={{
+				themeStorageKey: THEME_STORAGE_KEY,
+				themePreferences: THEME_PREFERENCES,
+				faviconTargets: FAVICON_TARGETS,
+			}}
+		>
 			(function () {
-				const THEME_KEY = 'theme';
+				const THEME_KEY = themeStorageKey;
+				const VALID_PREFERENCES = themePreferences;
+				const FAVICONS = faviconTargets;
 				const stored = (function () { try { return localStorage.getItem(THEME_KEY); } catch { return null; } })();
-				const preference = stored === 'light' || stored === 'dark' || stored === 'system' ? stored : 'system';
+				const preference = VALID_PREFERENCES.includes(stored) ? stored : 'system';
 				document.documentElement.setAttribute('data-theme-preference', preference);
 
 				function applyTheme(dark) {
@@ -50,7 +64,7 @@ const {
 					const favicon = document.querySelector('link[rel="icon"]:not([media])');
 					if (favicon) {
 						const isDark = document.documentElement.classList.contains('dark');
-						favicon.href = isDark ? '/favicon-dark-mode.svg' : '/favicon-light-mode.svg';
+						favicon.href = isDark ? FAVICONS.dark : FAVICONS.light;
 					}
 				};
 				document.readyState === 'loading' ? document.addEventListener('DOMContentLoaded', setFavicon) : setFavicon();
@@ -127,4 +141,3 @@ const {
 		</script>
 	</body>
 </html> 
-

--- a/src/utils/icon-button-contract.test.ts
+++ b/src/utils/icon-button-contract.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getIconButtonClasses } from "./icon-button-contract";
+
+describe("icon-button-contract", () => {
+  it("returns default variant classes with caller class appended", () => {
+    const classes = getIconButtonClasses("default", "icon-button--active");
+
+    expect(classes).toContain("icon-button");
+    expect(classes).toContain(
+      "border-2 border-border bg-canvas text-foreground",
+    );
+    expect(classes).toContain("icon-button--active");
+  });
+
+  it("returns inherit variant classes", () => {
+    const classes = getIconButtonClasses("inherit");
+
+    expect(classes).toContain(
+      "border-2 border-transparent bg-transparent text-inherit",
+    );
+    expect(classes).toContain("focus-visible:outline-currentColor");
+  });
+
+  it("returns borderless variant classes", () => {
+    const classes = getIconButtonClasses("borderless");
+
+    expect(classes).toContain("border-0 bg-canvas text-foreground");
+    expect(classes).toContain("hover:bg-accent-as-surface");
+    expect(classes).not.toContain("border-border");
+  });
+});

--- a/src/utils/icon-button-contract.ts
+++ b/src/utils/icon-button-contract.ts
@@ -1,0 +1,21 @@
+export type IconButtonVariant = "default" | "inherit" | "borderless";
+
+const DEFAULT_CLASSES =
+  "icon-button inline-flex items-center justify-center p-2 border-2 border-border bg-canvas text-foreground transition-all duration-150 cursor-pointer [@media(hover:hover)]:hover:bg-accent-as-surface [@media(hover:hover)]:hover:text-accent-as-surface-foreground [@media(hover:hover)]:hover:border-accent-as-surface focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2";
+
+const INHERIT_CLASSES =
+  "icon-button inline-flex items-center justify-center p-2 border-2 border-transparent bg-transparent text-inherit transition-all duration-150 cursor-pointer [@media(hover:hover)]:hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-currentColor";
+
+const BORDERLESS_CLASSES =
+  "icon-button inline-flex items-center justify-center p-2 border-0 bg-canvas text-foreground transition-all duration-150 cursor-pointer [@media(hover:hover)]:hover:bg-accent-as-surface [@media(hover:hover)]:hover:text-accent-as-surface-foreground focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2";
+
+const VARIANT_CLASSES: Record<IconButtonVariant, string> = {
+  default: DEFAULT_CLASSES,
+  inherit: INHERIT_CLASSES,
+  borderless: BORDERLESS_CLASSES,
+};
+
+export const getIconButtonClasses = (
+  variant: IconButtonVariant,
+  extraClass?: string,
+): string => [VARIANT_CLASSES[variant], extraClass].filter(Boolean).join(" ");

--- a/src/utils/nav-tile-contract.test.ts
+++ b/src/utils/nav-tile-contract.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getNavTileState } from "./nav-tile-contract";
+
+describe("nav-tile-contract", () => {
+  it("returns disabled semantics and non-interactive classes", () => {
+    const state = getNavTileState(true);
+
+    expect(state.ariaDisabled).toBe("true");
+    expect(state.containerClass).toContain("pointer-events-none");
+  });
+
+  it("returns enabled semantics and interactive classes", () => {
+    const state = getNavTileState(false);
+
+    expect(state.ariaDisabled).toBeUndefined();
+    expect(state.containerClass).toContain("hover:border-accent");
+    expect(state.showsDisabledLabel).toBe(false);
+  });
+
+  it("switches title and trailing styles by state", () => {
+    const disabledState = getNavTileState(true);
+    const enabledState = getNavTileState(false);
+
+    expect(disabledState.titleClass).toContain("text-muted");
+    expect(disabledState.trailingClass).toContain("tracking-[0.2em]");
+    expect(enabledState.titleClass).toContain("text-foreground");
+    expect(enabledState.trailingClass).toContain("shrink-0");
+  });
+});

--- a/src/utils/nav-tile-contract.ts
+++ b/src/utils/nav-tile-contract.ts
@@ -1,0 +1,46 @@
+export interface NavTileState {
+  containerClass: string;
+  titleClass: string;
+  trailingClass: string;
+  ariaDisabled?: "true";
+  showsDisabledLabel: boolean;
+}
+
+const SHARED_CONTAINER_CLASS =
+  "flex items-center justify-between border-2 text-foreground no-underline transition-all duration-150 w-full relative gap-4 px-5 md:px-6 [-webkit-tap-highlight-color:transparent]";
+
+const ENABLED_CONTAINER_CLASS =
+  "border-border border-t-2 bg-surface py-7 md:py-8 [@media(hover:hover)]:hover:border-accent active:border-accent focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2";
+
+const DISABLED_CONTAINER_CLASS =
+  "border-t-0 !border-border bg-canvas py-6 md:py-7 cursor-not-allowed pointer-events-none";
+
+const ENABLED_TITLE_CLASS =
+  "text-sm font-medium tracking-widest uppercase leading-tight text-foreground";
+
+const DISABLED_TITLE_CLASS =
+  "text-sm font-medium tracking-widest uppercase leading-tight text-muted";
+
+const ENABLED_TRAILING_CLASS = "flex items-center shrink-0";
+
+const DISABLED_TRAILING_CLASS =
+  "text-xs uppercase tracking-[0.2em] font-semibold text-muted";
+
+export const getNavTileState = (disabled: boolean): NavTileState => {
+  if (disabled) {
+    return {
+      containerClass: `${SHARED_CONTAINER_CLASS} ${DISABLED_CONTAINER_CLASS}`,
+      titleClass: DISABLED_TITLE_CLASS,
+      trailingClass: DISABLED_TRAILING_CLASS,
+      ariaDisabled: "true",
+      showsDisabledLabel: true,
+    };
+  }
+
+  return {
+    containerClass: `${SHARED_CONTAINER_CLASS} ${ENABLED_CONTAINER_CLASS}`,
+    titleClass: ENABLED_TITLE_CLASS,
+    trailingClass: ENABLED_TRAILING_CLASS,
+    showsDisabledLabel: false,
+  };
+};

--- a/src/utils/theme-manager.test.ts
+++ b/src/utils/theme-manager.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { THEME_STORAGE_KEY } from "./theme-runtime-contract";
 import {
   getActualTheme,
   getCurrentPreference,
@@ -95,20 +96,20 @@ describe("theme-manager", () => {
   describe("getCurrentPreference", () => {
     it("prefers data-theme-preference attribute when present", () => {
       document.documentElement.setAttribute("data-theme-preference", "dark");
-      window.localStorage.setItem("theme", "light");
+      window.localStorage.setItem(THEME_STORAGE_KEY, "light");
 
       expect(getCurrentPreference()).toBe("dark");
     });
 
     it("falls back to localStorage when attribute is missing", () => {
-      window.localStorage.setItem("theme", "light");
+      window.localStorage.setItem(THEME_STORAGE_KEY, "light");
       expect(getCurrentPreference()).toBe("light");
     });
 
     it("defaults to system when nothing is set or value is invalid", () => {
       expect(getCurrentPreference()).toBe("system");
 
-      window.localStorage.setItem("theme", "invalid");
+      window.localStorage.setItem(THEME_STORAGE_KEY, "invalid");
       expect(getCurrentPreference()).toBe("system");
     });
   });
@@ -133,7 +134,7 @@ describe("theme-manager", () => {
 
       setLightTheme(elements);
 
-      expect(window.localStorage.getItem("theme")).toBe("light");
+      expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
       expect(
         document.documentElement.getAttribute("data-theme-preference"),
       ).toBe("light");
@@ -163,7 +164,7 @@ describe("theme-manager", () => {
 
       setDarkTheme(elements);
 
-      expect(window.localStorage.getItem("theme")).toBe("dark");
+      expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
       expect(
         document.documentElement.getAttribute("data-theme-preference"),
       ).toBe("dark");
@@ -201,7 +202,7 @@ describe("theme-manager", () => {
 
       setSystemTheme(elements);
 
-      expect(window.localStorage.getItem("theme")).toBe("system");
+      expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("system");
       expect(
         document.documentElement.getAttribute("data-theme-preference"),
       ).toBe("system");
@@ -217,7 +218,7 @@ describe("theme-manager", () => {
 
   describe("initializeThemeManager", () => {
     it("initializes theme and makes buttons interactive", () => {
-      window.localStorage.setItem("theme", "dark");
+      window.localStorage.setItem(THEME_STORAGE_KEY, "dark");
 
       initializeThemeManager();
 

--- a/src/utils/theme-manager.test.ts
+++ b/src/utils/theme-manager.test.ts
@@ -129,6 +129,76 @@ describe("theme-manager", () => {
   });
 
   describe("setLightTheme / setDarkTheme / setSystemTheme", () => {
+    it("keeps exactly one active control for each preference", () => {
+      const elements = createThemeElements();
+
+      setLightTheme(elements);
+      {
+        const { lightThemeButton, systemThemeButton, darkThemeButton } =
+          getButtons();
+        const activeByClass = [
+          lightThemeButton,
+          systemThemeButton,
+          darkThemeButton,
+        ].filter((button) => button.classList.contains("icon-button--active"));
+        const activeByAria = [
+          lightThemeButton,
+          systemThemeButton,
+          darkThemeButton,
+        ].filter((button) => button.getAttribute("aria-pressed") === "true");
+        expect(activeByClass).toHaveLength(1);
+        expect(activeByAria).toHaveLength(1);
+      }
+
+      setDarkTheme(elements);
+      {
+        const { lightThemeButton, systemThemeButton, darkThemeButton } =
+          getButtons();
+        const activeByClass = [
+          lightThemeButton,
+          systemThemeButton,
+          darkThemeButton,
+        ].filter((button) => button.classList.contains("icon-button--active"));
+        const activeByAria = [
+          lightThemeButton,
+          systemThemeButton,
+          darkThemeButton,
+        ].filter((button) => button.getAttribute("aria-pressed") === "true");
+        expect(activeByClass).toHaveLength(1);
+        expect(activeByAria).toHaveLength(1);
+      }
+
+      setSystemTheme(elements);
+      {
+        const { lightThemeButton, systemThemeButton, darkThemeButton } =
+          getButtons();
+        const activeByClass = [
+          lightThemeButton,
+          systemThemeButton,
+          darkThemeButton,
+        ].filter((button) => button.classList.contains("icon-button--active"));
+        const activeByAria = [
+          lightThemeButton,
+          systemThemeButton,
+          darkThemeButton,
+        ].filter((button) => button.getAttribute("aria-pressed") === "true");
+        expect(activeByClass).toHaveLength(1);
+        expect(activeByAria).toHaveLength(1);
+      }
+    });
+
+    it("marks only the selected control as aria-pressed", () => {
+      const elements = createThemeElements();
+
+      setLightTheme(elements);
+
+      const { lightThemeButton, systemThemeButton, darkThemeButton } =
+        getButtons();
+      expect(lightThemeButton.getAttribute("aria-pressed")).toBe("true");
+      expect(systemThemeButton.getAttribute("aria-pressed")).toBe("false");
+      expect(darkThemeButton.getAttribute("aria-pressed")).toBe("false");
+    });
+
     it("sets light theme correctly", () => {
       const elements = createThemeElements();
 
@@ -217,6 +287,77 @@ describe("theme-manager", () => {
   });
 
   describe("initializeThemeManager", () => {
+    it("supports legacy matchMedia listener APIs without failing", () => {
+      const addListener = vi.fn();
+      vi.stubGlobal("matchMedia", () => ({
+        matches: false,
+        media: "(prefers-color-scheme: dark)",
+        addListener,
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      initializeThemeManager();
+
+      expect(addListener).toHaveBeenCalledTimes(1);
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("updates theme on system change only when preference is system", () => {
+      let prefersDark = false;
+      let systemChangeListener: ((event: MediaQueryListEvent) => void) | null =
+        null;
+
+      vi.stubGlobal("matchMedia", () => ({
+        get matches() {
+          return prefersDark;
+        },
+        media: "(prefers-color-scheme: dark)",
+        addEventListener: (
+          eventName: string,
+          listener: (event: MediaQueryListEvent) => void,
+        ) => {
+          if (eventName === "change") {
+            systemChangeListener = listener;
+          }
+        },
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+
+      window.localStorage.setItem(THEME_STORAGE_KEY, "system");
+      initializeThemeManager();
+
+      expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+
+      prefersDark = true;
+      systemChangeListener?.({ matches: true } as MediaQueryListEvent);
+
+      expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+
+      const favicon = document.querySelector(
+        'link[rel="icon"]:not([media])',
+      ) as HTMLLinkElement | null;
+      expect(favicon?.href.endsWith("/favicon-dark-mode.svg")).toBe(true);
+
+      const { systemThemeButton } = getButtons();
+      expect(systemThemeButton.getAttribute("aria-pressed")).toBe("true");
+
+      const { lightThemeButton } = getButtons();
+      lightThemeButton.click();
+      expect(
+        document.documentElement.getAttribute("data-theme-preference"),
+      ).toBe("light");
+
+      prefersDark = false;
+      systemChangeListener?.({ matches: false } as MediaQueryListEvent);
+
+      expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+      expect(lightThemeButton.getAttribute("aria-pressed")).toBe("true");
+    });
+
     it("initializes theme and makes buttons interactive", () => {
       window.localStorage.setItem(THEME_STORAGE_KEY, "dark");
 

--- a/src/utils/theme-manager.ts
+++ b/src/utils/theme-manager.ts
@@ -1,6 +1,13 @@
-// Theme types
-export type ThemePreference = "light" | "dark" | "system";
-export type ActualTheme = "light" | "dark";
+import {
+  FAVICON_SELECTOR,
+  THEME_STORAGE_KEY,
+  getDocumentThemeAttributes,
+  getFaviconTarget,
+  normalizeThemePreference,
+  resolveActualTheme,
+  type ActualTheme,
+  type ThemePreference,
+} from "./theme-runtime-contract";
 
 // Verified theme elements type (monogram optional — not present on all pages)
 type ThemeElements = {
@@ -18,7 +25,7 @@ const SELECTORS = {
   systemThemeButton: "#system-theme-button",
   darkThemeButton: "#dark-theme-button",
   monogram: "#monogram",
-  favicon: 'link[rel="icon"]:not([media])',
+  favicon: FAVICON_SELECTOR,
 } as const;
 
 // Safe localStorage operations
@@ -39,21 +46,21 @@ const safeLocalStorageSet = (key: string, value: string): void => {
 };
 
 const getStoredPreferenceFromLocalStorage = (): ThemePreference => {
-  const stored = safeLocalStorageGet("theme");
-  if (stored === "light" || stored === "dark" || stored === "system") {
-    return stored;
-  }
-  return "system";
+  return normalizeThemePreference(safeLocalStorageGet(THEME_STORAGE_KEY));
 };
 
 // Core theme functions (coordinated with inline script)
 const getSystemTheme = (): ActualTheme =>
-  window.matchMedia?.("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light";
+  resolveActualTheme(
+    "system",
+    Boolean(window.matchMedia?.("(prefers-color-scheme: dark)").matches),
+  );
 
 const getActualTheme = (preference: ThemePreference): ActualTheme =>
-  preference === "system" ? getSystemTheme() : (preference as ActualTheme);
+  resolveActualTheme(
+    preference,
+    Boolean(window.matchMedia?.("(prefers-color-scheme: dark)").matches),
+  );
 
 // Read current state (set by inline script or previous interactions)
 const getCurrentPreference = (): ThemePreference => {
@@ -111,8 +118,7 @@ const updateFavicon = (theme: ActualTheme): void => {
     SELECTORS.favicon,
   ) as HTMLLinkElement | null;
   if (favicon) {
-    favicon.href =
-      theme === "light" ? "/favicon-light-mode.svg" : "/favicon-dark-mode.svg";
+    favicon.href = getFaviconTarget(theme);
   }
 };
 
@@ -159,9 +165,14 @@ const updateDocumentAttributes = (
   preference: ThemePreference,
   actualTheme: ActualTheme,
 ): void => {
-  document.documentElement.setAttribute("data-theme", actualTheme);
-  document.documentElement.setAttribute("data-theme-preference", preference);
-  if (actualTheme === "dark") {
+  const attributes = getDocumentThemeAttributes(preference, actualTheme);
+
+  document.documentElement.setAttribute("data-theme", attributes.dataTheme);
+  document.documentElement.setAttribute(
+    "data-theme-preference",
+    attributes.dataThemePreference,
+  );
+  if (attributes.isDarkClass) {
     document.documentElement.classList.add("dark");
   } else {
     document.documentElement.classList.remove("dark");
@@ -195,17 +206,17 @@ const syncThemeFromStorage = (): void => {
 
 // User action handlers
 const setLightTheme = (elements: ThemeElements): void => {
-  safeLocalStorageSet("theme", "light");
+  safeLocalStorageSet(THEME_STORAGE_KEY, "light");
   updateThemeUI("light", elements);
 };
 
 const setSystemTheme = (elements: ThemeElements): void => {
-  safeLocalStorageSet("theme", "system");
+  safeLocalStorageSet(THEME_STORAGE_KEY, "system");
   updateThemeUI("system", elements);
 };
 
 const setDarkTheme = (elements: ThemeElements): void => {
-  safeLocalStorageSet("theme", "dark");
+  safeLocalStorageSet(THEME_STORAGE_KEY, "dark");
   updateThemeUI("dark", elements);
 };
 

--- a/src/utils/theme-manager.ts
+++ b/src/utils/theme-manager.ts
@@ -150,6 +150,9 @@ const updateButtonStates = (
   lightThemeButton.classList.remove("icon-button--active");
   systemThemeButton.classList.remove("icon-button--active");
   darkThemeButton.classList.remove("icon-button--active");
+  lightThemeButton.setAttribute("aria-pressed", "false");
+  systemThemeButton.setAttribute("aria-pressed", "false");
+  darkThemeButton.setAttribute("aria-pressed", "false");
 
   // Add active state to current preference
   const activeButton =
@@ -159,6 +162,7 @@ const updateButtonStates = (
         ? darkThemeButton
         : systemThemeButton;
   activeButton.classList.add("icon-button--active");
+  activeButton.setAttribute("aria-pressed", "true");
 };
 
 const updateDocumentAttributes = (
@@ -235,6 +239,24 @@ const createSystemChangeHandler = (elements: ThemeElements) => (): void => {
   }
 };
 
+const registerSystemThemeChangeListener = (
+  listener: (event: MediaQueryListEvent) => void,
+): void => {
+  const mediaQueryList = window.matchMedia("(prefers-color-scheme: dark)");
+  if (typeof mediaQueryList.addEventListener === "function") {
+    mediaQueryList.addEventListener("change", listener);
+    return;
+  }
+
+  const legacyMediaQueryList = mediaQueryList as MediaQueryList & {
+    addListener?: (listener: (event: MediaQueryListEvent) => void) => void;
+  };
+
+  if (typeof legacyMediaQueryList.addListener === "function") {
+    legacyMediaQueryList.addListener(listener);
+  }
+};
+
 // Event listener setup
 const setupEventListeners = (elements: ThemeElements): void => {
   const { lightThemeButton, systemThemeButton, darkThemeButton } = elements;
@@ -267,9 +289,7 @@ const setupEventListeners = (elements: ThemeElements): void => {
   });
 
   // Listen for system theme changes
-  window
-    .matchMedia("(prefers-color-scheme: dark)")
-    .addEventListener("change", createSystemChangeHandler(elements));
+  registerSystemThemeChangeListener(createSystemChangeHandler(elements));
 };
 
 // Main initialization

--- a/src/utils/theme-runtime-contract.test.ts
+++ b/src/utils/theme-runtime-contract.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  FAVICON_SELECTOR,
+  THEME_PREFERENCES,
+  THEME_STORAGE_KEY,
+  getDocumentThemeAttributes,
+  getFaviconTarget,
+  normalizeThemePreference,
+  resolveActualTheme,
+} from "./theme-runtime-contract";
+
+describe("theme-runtime-contract", () => {
+  it("defines canonical theme preferences and storage key", () => {
+    expect(THEME_STORAGE_KEY).toBe("theme");
+    expect(THEME_PREFERENCES).toEqual(["light", "dark", "system"]);
+    expect(FAVICON_SELECTOR).toBe('link[rel="icon"]:not([media])');
+  });
+
+  it("normalizes invalid or missing preferences to system", () => {
+    expect(normalizeThemePreference("light")).toBe("light");
+    expect(normalizeThemePreference("dark")).toBe("dark");
+    expect(normalizeThemePreference("system")).toBe("system");
+    expect(normalizeThemePreference("invalid")).toBe("system");
+    expect(normalizeThemePreference(null)).toBe("system");
+    expect(normalizeThemePreference(undefined)).toBe("system");
+  });
+
+  it("resolves actual theme for explicit and system preferences", () => {
+    expect(resolveActualTheme("light", true)).toBe("light");
+    expect(resolveActualTheme("dark", false)).toBe("dark");
+    expect(resolveActualTheme("system", false)).toBe("light");
+    expect(resolveActualTheme("system", true)).toBe("dark");
+  });
+
+  it("returns document attributes for resolved theme", () => {
+    expect(getDocumentThemeAttributes("system", "dark")).toEqual({
+      dataTheme: "dark",
+      dataThemePreference: "system",
+      isDarkClass: true,
+    });
+
+    expect(getDocumentThemeAttributes("light", "light")).toEqual({
+      dataTheme: "light",
+      dataThemePreference: "light",
+      isDarkClass: false,
+    });
+  });
+
+  it("selects favicon target by resolved theme", () => {
+    expect(getFaviconTarget("light")).toBe("/favicon-light-mode.svg");
+    expect(getFaviconTarget("dark")).toBe("/favicon-dark-mode.svg");
+  });
+});

--- a/src/utils/theme-runtime-contract.ts
+++ b/src/utils/theme-runtime-contract.ts
@@ -1,0 +1,47 @@
+export const THEME_STORAGE_KEY = "theme";
+
+export const THEME_PREFERENCES = ["light", "dark", "system"] as const;
+
+export type ThemePreference = (typeof THEME_PREFERENCES)[number];
+export type ActualTheme = "light" | "dark";
+
+export const FAVICON_SELECTOR = 'link[rel="icon"]:not([media])';
+
+export const FAVICON_TARGETS = {
+  light: "/favicon-light-mode.svg",
+  dark: "/favicon-dark-mode.svg",
+} as const;
+
+export const normalizeThemePreference = (
+  candidate: string | null | undefined,
+): ThemePreference =>
+  candidate === "light" || candidate === "dark" || candidate === "system"
+    ? candidate
+    : "system";
+
+export const resolveActualTheme = (
+  preference: ThemePreference,
+  systemPrefersDark: boolean,
+): ActualTheme => {
+  if (preference === "light") {
+    return "light";
+  }
+
+  if (preference === "dark") {
+    return "dark";
+  }
+
+  return systemPrefersDark ? "dark" : "light";
+};
+
+export const getDocumentThemeAttributes = (
+  preference: ThemePreference,
+  actualTheme: ActualTheme,
+) => ({
+  dataTheme: actualTheme,
+  dataThemePreference: preference,
+  isDarkClass: actualTheme === "dark",
+});
+
+export const getFaviconTarget = (theme: ActualTheme): string =>
+  FAVICON_TARGETS[theme];

--- a/tests/README.md
+++ b/tests/README.md
@@ -184,12 +184,15 @@ Performance Budget Check (Build Size)
   - Keeps the site intentionally **small and fast** by:
     - Capping HTML, CSS, and JS growth.
     - Making any significant weight increase visible in CI.
+  - The budget is a descriptive reference signal for SDP work, not an automatic product veto:
+    - A budget movement should be recorded and understood.
+    - A refactor should only treat the budget as a hard blocker when the active cycle explicitly says so.
   - During refactors:
     - If this test fails, inspect `dist/` to see which assets grew.
     - Typical follow‑ups:
       - Remove unused CSS or JS.
-      - Split or compress assets.
-      - Re‑evaluate whether the new weight is justified and, if so, consider adjusting the budget intentionally.
+      - Split or compress assets when that serves the current cycle.
+      - Re‑evaluate whether the new weight is justified and record the trade-off when it is.
 
 ---
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,12 +1,14 @@
 Testing Overview
 ================
 
-This document describes the automated checks we run against this site and the current baseline as of **2026‑03‑06**.  
+This document describes the automated checks we run against this site and the current baseline as of **2026-05-09**.  
 Use it as a guide during refactors: if a test starts failing, this explains what changed and why it matters.
 
 We group tests into:
 
 - Unit tests (Vitest, colocated with source files)
+- Theme first-paint verification tests (Playwright)
+- Route-surface contract tests (Playwright)
 - Visual regression tests (Playwright)
 - Accessibility tests (Playwright + axe-core)
 - Lighthouse audits (performance, a11y, best practices, SEO)
@@ -19,6 +21,52 @@ Each section below explains:
 - **How we run it**
 - **What “pass” means today**
 - **Why we keep this test**
+
+---
+
+Theme First-Paint Verification Tests
+------------------------------------
+
+- **What we test**
+  - File: `tests/theme-first-paint.spec.ts`
+  - Pages covered: `/` and `/writing`
+  - Preferences covered:
+    - `light`
+    - `dark`
+    - `system` under both light and dark OS schemes
+  - For each page/preference scenario, Playwright:
+    - Preloads `window.localStorage.theme` before boot.
+    - Navigates with `waitUntil: "commit"` to inspect earliest paint state.
+    - Verifies `data-theme`, `data-theme-preference`, `dark` class state, and favicon target.
+
+- **How we run it**
+  - Included in the full Playwright suite:
+    - `pnpm test`
+
+- **Why this test exists**
+  - Protects against first-paint theme flicker regressions.
+  - Confirms runtime theme attributes and favicon selection are coherent at document commit.
+
+---
+
+Route-Surface Contract Tests
+----------------------------
+
+- **What we test**
+  - Files:
+    - `tests/cartouche.spec.ts`
+    - `tests/cta.spec.ts`
+  - Current checks:
+    - Cartouche variant markers are present and route-specific (`hero` on `/`, `section` on `/writing`).
+    - Writing-page CTA renders the expected anchor semantics and external-link safety attributes.
+
+- **How we run it**
+  - Included in the full Playwright suite:
+    - `pnpm test`
+
+- **Why this test exists**
+  - Locks down stable data-attribute contracts used to assert intended render paths.
+  - Catches regressions in component semantics without relying on snapshot diffs.
 
 ---
 
@@ -223,9 +271,10 @@ Static Analysis: Formatting and Linting
       - Runs, in order:
         1. `pnpm format:check`
         2. `pnpm lint`
-        3. `pnpm test` \(all Playwright tests\)
-        4. `pnpm test:lighthouse`
-        5. `pnpm test:build`
+        3. `pnpm test:unit`
+        4. `pnpm test` \(all Playwright tests\)
+        5. `pnpm test:lighthouse`
+        6. `pnpm test:build`
 
 - **Current result (baseline)**
   - As of this document, the codebase is expected to:
@@ -274,6 +323,12 @@ Unit Tests (Vitest)
   - Colocated unit tests that live next to the code they exercise. For example:
     - `src/utils/theme-manager.ts`
     - `src/utils/theme-manager.test.ts`
+    - `src/utils/theme-runtime-contract.ts`
+    - `src/utils/theme-runtime-contract.test.ts`
+    - `src/utils/icon-button-contract.ts`
+    - `src/utils/icon-button-contract.test.ts`
+    - `src/utils/nav-tile-contract.ts`
+    - `src/utils/nav-tile-contract.test.ts`
   - These tests focus on:
     - Module-level logic (e.g. how theme preferences map to actual themes).
     - DOM updates performed by a specific utility or component in isolation.
@@ -282,6 +337,8 @@ Unit Tests (Vitest)
 - **Where tests live**
   - Unit tests are **usually placed alongside the file they test** under `src/`.
   - The top-level `tests/` folder is reserved for **broader app-level tests**, such as:
+    - Theme first-paint checks in `tests/theme-first-paint.spec.ts`.
+    - Route-surface contract checks in `tests/cartouche.spec.ts` and `tests/cta.spec.ts`.
     - Visual regression tests in `tests/visual.spec.ts`.
     - Accessibility tests in `tests/a11y.spec.ts`.
 - **Why this test exists**

--- a/tests/a11y.spec.ts
+++ b/tests/a11y.spec.ts
@@ -1,21 +1,28 @@
 import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
+import {
+  THEME_PREFERENCES,
+  THEME_STORAGE_KEY,
+} from "../src/utils/theme-runtime-contract";
 
 const pages = ["/", "/writing"] as const;
-const themes = ["light", "dark", "system"] as const;
+const themes = THEME_PREFERENCES;
 
 for (const pagePath of pages) {
   for (const theme of themes) {
     test(`@a11y ${pagePath} [${theme}] has no axe-core violations`, async ({
       page,
     }) => {
-      await page.addInitScript((preference) => {
-        try {
-          window.localStorage.setItem("theme", preference);
-        } catch {
-          // ignore
-        }
-      }, theme);
+      await page.addInitScript(
+        ({ preference, storageKey }) => {
+          try {
+            window.localStorage.setItem(storageKey, preference);
+          } catch {
+            // ignore
+          }
+        },
+        { preference: theme, storageKey: THEME_STORAGE_KEY },
+      );
 
       await page.goto(pagePath, { waitUntil: "networkidle" });
 

--- a/tests/cartouche.spec.ts
+++ b/tests/cartouche.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test("cartouche exposes variant markers on home and writing surfaces", async ({
+  page,
+}) => {
+  await page.goto("/", { waitUntil: "networkidle" });
+
+  const homeCartouche = page.locator('[data-cartouche="true"]');
+  await expect(homeCartouche).toHaveCount(1);
+  await expect(homeCartouche).toHaveAttribute("data-cartouche-variant", "hero");
+
+  await page.goto("/writing", { waitUntil: "networkidle" });
+
+  const writingCartouche = page.locator('[data-cartouche="true"]');
+  await expect(writingCartouche).toHaveCount(1);
+  await expect(writingCartouche).toHaveAttribute(
+    "data-cartouche-variant",
+    "section",
+  );
+});

--- a/tests/cta.spec.ts
+++ b/tests/cta.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("CTA exposes route-surface contract markers and external-link behavior", async ({
+  page,
+}) => {
+  await page.goto("/writing", { waitUntil: "networkidle" });
+
+  const cta = page.locator('[data-cta="true"]');
+  await expect(cta).toHaveCount(1);
+  await expect(cta).toHaveAttribute("data-cta-as", "a");
+  await expect(cta).toHaveAttribute("target", "_blank");
+  await expect(cta).toHaveAttribute("rel", "noopener noreferrer");
+});

--- a/tests/theme-first-paint.spec.ts
+++ b/tests/theme-first-paint.spec.ts
@@ -1,0 +1,284 @@
+import { expect, test } from "@playwright/test";
+import {
+  FAVICON_SELECTOR,
+  FAVICON_TARGETS,
+  THEME_STORAGE_KEY,
+} from "../src/utils/theme-runtime-contract";
+
+test("@firstpaint / [light] applies theme state at commit", async ({
+  page,
+}) => {
+  await page.addInitScript(
+    ({ preference, storageKey }) => {
+      try {
+        window.localStorage.setItem(storageKey, preference);
+      } catch {
+        // ignore storage restrictions in test browser contexts
+      }
+    },
+    { preference: "light", storageKey: THEME_STORAGE_KEY },
+  );
+
+  await page.goto("/", { waitUntil: "commit" });
+
+  const firstPaintState = await page.evaluate((faviconSelector) => {
+    const root = document.documentElement;
+    const favicon = document.querySelector(faviconSelector);
+
+    return {
+      dataTheme: root.getAttribute("data-theme"),
+      dataThemePreference: root.getAttribute("data-theme-preference"),
+      isDarkClassApplied: root.classList.contains("dark"),
+      faviconHref: favicon instanceof HTMLLinkElement ? favicon.href : null,
+    };
+  }, FAVICON_SELECTOR);
+
+  expect(firstPaintState.dataTheme).toBe("light");
+  expect(firstPaintState.dataThemePreference).toBe("light");
+  expect(firstPaintState.isDarkClassApplied).toBe(false);
+  expect(firstPaintState.faviconHref).toContain(FAVICON_TARGETS.light);
+});
+
+test("@firstpaint /writing [dark] applies theme state at commit", async ({
+  page,
+}) => {
+  await page.addInitScript(
+    ({ preference, storageKey }) => {
+      try {
+        window.localStorage.setItem(storageKey, preference);
+      } catch {
+        // ignore storage restrictions in test browser contexts
+      }
+    },
+    { preference: "dark", storageKey: THEME_STORAGE_KEY },
+  );
+
+  await page.goto("/writing", { waitUntil: "commit" });
+
+  const firstPaintState = await page.evaluate((faviconSelector) => {
+    const root = document.documentElement;
+    const favicon = document.querySelector(faviconSelector);
+
+    return {
+      dataTheme: root.getAttribute("data-theme"),
+      dataThemePreference: root.getAttribute("data-theme-preference"),
+      isDarkClassApplied: root.classList.contains("dark"),
+      faviconHref: favicon instanceof HTMLLinkElement ? favicon.href : null,
+    };
+  }, FAVICON_SELECTOR);
+
+  expect(firstPaintState.dataTheme).toBe("dark");
+  expect(firstPaintState.dataThemePreference).toBe("dark");
+  expect(firstPaintState.isDarkClassApplied).toBe(true);
+  expect(firstPaintState.faviconHref).toContain(FAVICON_TARGETS.dark);
+});
+
+test("@firstpaint / [dark] applies theme state at commit", async ({ page }) => {
+  await page.addInitScript(
+    ({ preference, storageKey }) => {
+      try {
+        window.localStorage.setItem(storageKey, preference);
+      } catch {
+        // ignore storage restrictions in test browser contexts
+      }
+    },
+    { preference: "dark", storageKey: THEME_STORAGE_KEY },
+  );
+
+  await page.goto("/", { waitUntil: "commit" });
+
+  const firstPaintState = await page.evaluate((faviconSelector) => {
+    const root = document.documentElement;
+    const favicon = document.querySelector(faviconSelector);
+
+    return {
+      dataTheme: root.getAttribute("data-theme"),
+      dataThemePreference: root.getAttribute("data-theme-preference"),
+      isDarkClassApplied: root.classList.contains("dark"),
+      faviconHref: favicon instanceof HTMLLinkElement ? favicon.href : null,
+    };
+  }, FAVICON_SELECTOR);
+
+  expect(firstPaintState.dataTheme).toBe("dark");
+  expect(firstPaintState.dataThemePreference).toBe("dark");
+  expect(firstPaintState.isDarkClassApplied).toBe(true);
+  expect(firstPaintState.faviconHref).toContain(FAVICON_TARGETS.dark);
+});
+
+test("@firstpaint /writing [light] applies theme state at commit", async ({
+  page,
+}) => {
+  await page.addInitScript(
+    ({ preference, storageKey }) => {
+      try {
+        window.localStorage.setItem(storageKey, preference);
+      } catch {
+        // ignore storage restrictions in test browser contexts
+      }
+    },
+    { preference: "light", storageKey: THEME_STORAGE_KEY },
+  );
+
+  await page.goto("/writing", { waitUntil: "commit" });
+
+  const firstPaintState = await page.evaluate((faviconSelector) => {
+    const root = document.documentElement;
+    const favicon = document.querySelector(faviconSelector);
+
+    return {
+      dataTheme: root.getAttribute("data-theme"),
+      dataThemePreference: root.getAttribute("data-theme-preference"),
+      isDarkClassApplied: root.classList.contains("dark"),
+      faviconHref: favicon instanceof HTMLLinkElement ? favicon.href : null,
+    };
+  }, FAVICON_SELECTOR);
+
+  expect(firstPaintState.dataTheme).toBe("light");
+  expect(firstPaintState.dataThemePreference).toBe("light");
+  expect(firstPaintState.isDarkClassApplied).toBe(false);
+  expect(firstPaintState.faviconHref).toContain(FAVICON_TARGETS.light);
+});
+
+test.describe("@firstpaint system preference", () => {
+  test.use({ colorScheme: "light" });
+
+  test("/ [system-light] applies light theme at commit", async ({ page }) => {
+    await page.addInitScript(
+      ({ preference, storageKey }) => {
+        try {
+          window.localStorage.setItem(storageKey, preference);
+        } catch {
+          // ignore storage restrictions in test browser contexts
+        }
+      },
+      { preference: "system", storageKey: THEME_STORAGE_KEY },
+    );
+
+    await page.goto("/", { waitUntil: "commit" });
+
+    const firstPaintState = await page.evaluate((faviconSelector) => {
+      const root = document.documentElement;
+      const favicon = document.querySelector(faviconSelector);
+
+      return {
+        dataTheme: root.getAttribute("data-theme"),
+        dataThemePreference: root.getAttribute("data-theme-preference"),
+        isDarkClassApplied: root.classList.contains("dark"),
+        faviconHref: favicon instanceof HTMLLinkElement ? favicon.href : null,
+      };
+    }, FAVICON_SELECTOR);
+
+    expect(firstPaintState.dataTheme).toBe("light");
+    expect(firstPaintState.dataThemePreference).toBe("system");
+    expect(firstPaintState.isDarkClassApplied).toBe(false);
+    expect(firstPaintState.faviconHref).toContain(FAVICON_TARGETS.light);
+  });
+});
+
+test.describe("@firstpaint system preference dark", () => {
+  test.use({ colorScheme: "dark" });
+
+  test("/writing [system-dark] applies dark theme at commit", async ({
+    page,
+  }) => {
+    await page.addInitScript(
+      ({ preference, storageKey }) => {
+        try {
+          window.localStorage.setItem(storageKey, preference);
+        } catch {
+          // ignore storage restrictions in test browser contexts
+        }
+      },
+      { preference: "system", storageKey: THEME_STORAGE_KEY },
+    );
+
+    await page.goto("/writing", { waitUntil: "commit" });
+
+    const firstPaintState = await page.evaluate((faviconSelector) => {
+      const root = document.documentElement;
+      const favicon = document.querySelector(faviconSelector);
+
+      return {
+        dataTheme: root.getAttribute("data-theme"),
+        dataThemePreference: root.getAttribute("data-theme-preference"),
+        isDarkClassApplied: root.classList.contains("dark"),
+        faviconHref: favicon instanceof HTMLLinkElement ? favicon.href : null,
+      };
+    }, FAVICON_SELECTOR);
+
+    expect(firstPaintState.dataTheme).toBe("dark");
+    expect(firstPaintState.dataThemePreference).toBe("system");
+    expect(firstPaintState.isDarkClassApplied).toBe(true);
+    expect(firstPaintState.faviconHref).toContain(FAVICON_TARGETS.dark);
+  });
+
+  test("/ [system-dark] applies dark theme at commit", async ({ page }) => {
+    await page.addInitScript(
+      ({ preference, storageKey }) => {
+        try {
+          window.localStorage.setItem(storageKey, preference);
+        } catch {
+          // ignore storage restrictions in test browser contexts
+        }
+      },
+      { preference: "system", storageKey: THEME_STORAGE_KEY },
+    );
+
+    await page.goto("/", { waitUntil: "commit" });
+
+    const firstPaintState = await page.evaluate((faviconSelector) => {
+      const root = document.documentElement;
+      const favicon = document.querySelector(faviconSelector);
+
+      return {
+        dataTheme: root.getAttribute("data-theme"),
+        dataThemePreference: root.getAttribute("data-theme-preference"),
+        isDarkClassApplied: root.classList.contains("dark"),
+        faviconHref: favicon instanceof HTMLLinkElement ? favicon.href : null,
+      };
+    }, FAVICON_SELECTOR);
+
+    expect(firstPaintState.dataTheme).toBe("dark");
+    expect(firstPaintState.dataThemePreference).toBe("system");
+    expect(firstPaintState.isDarkClassApplied).toBe(true);
+    expect(firstPaintState.faviconHref).toContain(FAVICON_TARGETS.dark);
+  });
+});
+
+test.describe("@firstpaint system preference light writing", () => {
+  test.use({ colorScheme: "light" });
+
+  test("/writing [system-light] applies light theme at commit", async ({
+    page,
+  }) => {
+    await page.addInitScript(
+      ({ preference, storageKey }) => {
+        try {
+          window.localStorage.setItem(storageKey, preference);
+        } catch {
+          // ignore storage restrictions in test browser contexts
+        }
+      },
+      { preference: "system", storageKey: THEME_STORAGE_KEY },
+    );
+
+    await page.goto("/writing", { waitUntil: "commit" });
+
+    const firstPaintState = await page.evaluate((faviconSelector) => {
+      const root = document.documentElement;
+      const favicon = document.querySelector(faviconSelector);
+
+      return {
+        dataTheme: root.getAttribute("data-theme"),
+        dataThemePreference: root.getAttribute("data-theme-preference"),
+        isDarkClassApplied: root.classList.contains("dark"),
+        faviconHref: favicon instanceof HTMLLinkElement ? favicon.href : null,
+      };
+    }, FAVICON_SELECTOR);
+
+    expect(firstPaintState.dataTheme).toBe("light");
+    expect(firstPaintState.dataThemePreference).toBe("system");
+    expect(firstPaintState.isDarkClassApplied).toBe(false);
+    expect(firstPaintState.faviconHref).toContain(FAVICON_TARGETS.light);
+  });
+});

--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from "@playwright/test";
+import {
+  THEME_PREFERENCES,
+  THEME_STORAGE_KEY,
+} from "../src/utils/theme-runtime-contract";
 
 const pages = ["/", "/writing"] as const;
 
@@ -10,7 +14,7 @@ const viewports = [
   { name: "lg", width: 1280, height: 800 },
 ] as const;
 
-const themes = ["light", "dark", "system"] as const;
+const themes = THEME_PREFERENCES;
 
 for (const pagePath of pages) {
   for (const theme of themes) {
@@ -24,13 +28,16 @@ for (const pagePath of pages) {
         });
 
         // Ensure theme preference is set before the app script runs
-        await page.addInitScript((preference) => {
-          try {
-            window.localStorage.setItem("theme", preference);
-          } catch {
-            // ignore
-          }
-        }, theme);
+        await page.addInitScript(
+          ({ preference, storageKey }) => {
+            try {
+              window.localStorage.setItem(storageKey, preference);
+            } catch {
+              // ignore
+            }
+          },
+          { preference: theme, storageKey: THEME_STORAGE_KEY },
+        );
 
         await page.goto(pagePath, { waitUntil: "networkidle" });
 


### PR DESCRIPTION
- Introduces a canonical theme runtime contract and first-paint theme boot verification to keep data-theme, preference state, dark-class toggling, and favicon selection coherent from initial render.
- Adds primary render-path contracts for icon-button, nav-tile, cartouche, and cta, with route-surface markers and stronger semantic guarantees.
- Expands coverage with new unit contract tests and Playwright checks (first-paint + component route contracts), while existing visual/a11y/perf guardrails remain in place.

Closes #15 , Closes #16 , Closes #17 , Closes #18 , Closes #27 , Closes #28 , Closes #29 